### PR TITLE
Add switches for disabling image reading/writing

### DIFF
--- a/src/pixie.nim
+++ b/src/pixie.nim
@@ -1,6 +1,8 @@
-import pixie/images, pixie/masks, pixie/paths, pixie/common, pixie/blends,
-  pixie/fileformats/bmp, pixie/fileformats/png, pixie/fileformats/jpg,
-  pixie/fileformats/svg, flatty/binny, os
+import pixie/images, pixie/masks, pixie/paths, pixie/common, pixie/blends
+
+# When reading and writing is disabled, do not import any formats.
+when (not defined(pixieNoReadImage)) or (not defined(pixieNoWriteImage)):
+  import flatty/binny, os, pixie/fileformats/[bmp, png, jpg, svg]
 
 export images, masks, paths, common, blends
 
@@ -20,44 +22,49 @@ proc toImage*(mask: Mask): Image =
   for i in 0 ..< mask.data.len:
     result.data[i].a = mask.data[i]
 
-proc decodeImage*(data: string | seq[uint8]): Image =
-  ## Loads an image from a memory.
-  if data.len > 8 and data.readUint64(0) == cast[uint64](pngSignature):
-    decodePng(data)
-  elif data.len > 2 and data.readUint16(0) == cast[uint16](jpgStartOfImage):
-    decodeJpg(data)
-  elif data.len > 2 and data.readStr(0, 2) == bmpSignature:
-    decodeBmp(data)
-  elif data.len > 5 and data.readStr(0, 5) == svgSignature:
-    decodeSvg(data)
-  else:
-    raise newException(PixieError, "Unsupported image file format")
+when not defined(pixieNoReadImage):
 
-proc readImage*(filePath: string): Image =
-  ## Loads an image from a file.
-  decodeImage(readFile(filePath))
-
-proc encodeImage*(image: Image, fileFormat: FileFormat): string =
-  ## Encodes an image into memory.
-  case fileFormat:
-  of ffPng:
-    image.encodePng()
-  of ffJpg:
-    image.encodeJpg()
-  of ffBmp:
-    image.encodeBmp()
-
-proc writeFile*(image: Image, filePath: string, fileFormat: FileFormat) =
-  ## Writes an image to a file.
-  writeFile(filePath, image.encodeImage(fileFormat))
-
-proc writeFile*(image: Image, filePath: string) =
-  ## Writes an image to a file.
-  let fileFormat = case splitFile(filePath).ext:
-    of ".png": ffPng
-    of ".bmp": ffBmp
-    of ".jpg": ffJpg
-    of ".jpeg": ffJpg
+  proc decodeImage*(data: string | seq[uint8]): Image =
+    ## Loads an image from a memory.
+    if data.len > 8 and data.readUint64(0) == cast[uint64](pngSignature):
+      decodePng(data)
+    elif data.len > 2 and data.readUint16(0) == cast[uint16](jpgStartOfImage):
+      decodeJpg(data)
+    elif data.len > 2 and data.readStr(0, 2) == bmpSignature:
+      decodeBmp(data)
+    elif data.len > 5 and data.readStr(0, 5) == svgSignature:
+      decodeSvg(data)
     else:
-      raise newException(PixieError, "Unsupported image file extension")
-  image.writeFile(filePath, fileformat)
+      raise newException(PixieError, "Unsupported image file format")
+
+  proc readImage*(filePath: string): Image =
+    ## Loads an image from a file.
+    decodeImage(readFile(filePath))
+
+when not defined(pixieNoWriteImage):
+
+  proc encodeImage*(image: Image, fileFormat: FileFormat): string =
+    ## Encodes an image into memory.
+    case fileFormat:
+    of ffPng:
+      image.encodePng()
+    of ffJpg:
+      image.encodeJpg()
+    of ffBmp:
+      image.encodeBmp()
+
+  proc writeFile*(image: Image, filePath: string, fileFormat: FileFormat) =
+    ## Writes an image to a file.
+    writeFile(filePath, image.encodeImage(fileFormat))
+
+  proc writeFile*(image: Image, filePath: string) =
+    ## Writes an image to a file.
+    let fileFormat = case splitFile(filePath).ext:
+      of ".png": ffPng
+      of ".bmp": ffBmp
+      of ".jpg": ffJpg
+      of ".jpeg": ffJpg
+      else:
+        raise newException(PixieError, "Unsupported image file extension")
+    image.writeFile(filePath, fileformat)
+


### PR DESCRIPTION
This PR disables image reading/writing when `pixieNoReadImage`/`pixieNoWriteImage` are defined.

Motivation: I use `typography`, which depends on `pixie` but does not seem to use any image IO procs outside of tests. In my framework, I use `stb-image` with PNGs only. This leads to duplicate-symbol linker errors, since pixie uses stb_image as well.

Using pixie's image IO directly is possible, but leads to bloat, as my stb_image output is uploaded directly to OpenGL anyway, and I don't have any need for bmp/jpeg/svg support.

