### PR TITLE
Workaround for gc:arc SIGSEGV in png.nim

### DIFF
--- a/src/pixie/fileformats/png.nim
+++ b/src/pixie/fileformats/png.nim
@@ -437,9 +437,10 @@ proc encodePng*(
       raise newException(PixieError, "Invalid PNG number of channels")
 
   let data = cast[ptr UncheckedArray[uint8]](data)
+  const signature = [137.uint8, 80, 78, 71, 13, 10, 26, 10]
 
   # Add the PNG file signature
-  result.add([137.uint8, 80, 78, 71, 13, 10, 26, 10])
+  result.add(signature)
 
   # Add IHDR
   result.addUint32(13.uint32.swap())


### PR DESCRIPTION
Fixes a SIGSEGV caused by --gc:arc. Somehow. 

I was able to reproduce this with:
`nim r --gc:arc tests/test_png.nim`

```
pixie-master/tests/test_png.nim(9) test_png
pixie-master/src/pixie/fileformats/png.nim(500) encodePng
pixie-master/src/pixie/fileformats/png.nim(442) encodePng
nim-1.4.2/lib/system.nim(1242) add
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

This is caused by a Nim bug that only occurs on `1.4.2`. It is not present in `devel`.