### PR TITLE
faster subImage, a bit more

### DIFF
--- a/src/pixie/images.nim
+++ b/src/pixie/images.nim
@@ -127,8 +127,11 @@ proc subImage*(image: Image, x, y, w, h: int): Image =
 
   result = newImage(w, h)
   for y2 in 0 ..< h:
-    for x2 in 0 ..< w:
-      result.setRgbaUnsafe(x2, y2, image[x2 + x, y2 + y])
+    copyMem(
+      result.data[result.dataIndex(0, y2)].addr,
+      image.data[image.dataIndex(x, y + y2)].addr,
+      w * 4
+    )
 
 proc minifyBy2*(image: Image): Image =
   ## Scales the image down by an integer scale.

--- a/tests/benchmark_images.nim
+++ b/tests/benchmark_images.nim
@@ -1,4 +1,4 @@
-import chroma, pixie, benchy, system/memory
+import chroma, pixie, benchy
 
 let a = newImage(2560, 1440)
 
@@ -11,6 +11,9 @@ timeIt "fill_rgba":
   a.fill(rgba(63, 127, 191, 255))
   doAssert a[0, 0] == rgba(63, 127, 191, 255)
   keep(a)
+
+timeIt "subImage":
+  keep a.subImage(0, 0, 256, 256)
 
 timeIt "invert":
   a.invert()

--- a/tests/test_images.nim
+++ b/tests/test_images.nim
@@ -1,111 +1,32 @@
-import pixie, chroma, strutils, os, vmath
-
-proc writeAndCheck(image: Image, fileName: string) =
-  image.writeFile(fileName)
-  let masterFileName = fileName.replace("tests/images/", "tests/images/masters/")
-  if not fileExists(masterFileName):
-    echo "Master file: " & masterFileName & " not found!"
-    quit(-1)
-  var master = readImage(fileName)
-  assert image.width == master.width
-  assert image.height == master.height
-  assert image.data == master.data
-
-# block:
-#   var a = newImage(100, 100)
-#   a.fill(rgba(0, 0, 0, 0))
-#   var b = newImage(50, 50)
-#   b.fill(rgba(255, 92, 0, 255))
-#   var c = a.drawBlendSmooth(
-#     b,
-#     translate(vec2(50, 50)) * rotationMat3(0.2789281382) * translate(vec2(-25, -25)),
-#     bmNormal
-#   )
-#   c.writeAndCheck("tests/images/centerRotation.png")
-
-# block:
-#   var a = newImage(100, 100)
-#   a.fill(rgba(255, 255, 255, 255))
-#   var b = newImage(50, 50)
-#   b.fill(rgba(255, 92, 0, 255))
-#   var c = a.drawBlendSmooth(
-#     b,
-#     translate(vec2(50, 50)) * rotationMat3(0.2789281382) * translate(vec2(-25, -25)),
-#     bmNormal
-#   )
-#   c.writeAndCheck("tests/images/centerRotationWhite.png")
-
-
-# block:
-#   var a = newImage(100, 100)
-#   a.fill(rgba(0, 0, 0, 0))
-#   var b = newImage(50, 50)
-#   b.fill(rgba(255, 92, 0, 255))
-#   var c = a.drawBlendSmooth(
-#     b,
-#     translate(vec2(50, 50)) * rotationMat3(0.2789281382) * translate(vec2(-25, -25)),
-#     bmNormal
-#   )
-#   c.writeAndCheck("tests/images/transCompose.c.png")
-#   var d = newImage(100, 100)
-#   d = d.fill(rgba(255, 255, 255, 255))
-#   var e = d.draw(c)
-#   e.writeAndCheck("tests/images/transCompose.png")
+import pixie, chroma, vmath
 
 block:
-  var image = newImage(10, 10)
+  let image = newImage(10, 10)
   image[0, 0] = rgba(255, 255, 255, 255)
   doAssert image[0, 0] == rgba(255, 255, 255, 255)
 
 block:
-  var image = newImage(10, 10)
+  let image = newImage(10, 10)
   image.fill(rgba(255, 0, 0, 255))
   doAssert image[0, 0] == rgba(255, 0, 0, 255)
 
 block:
-  var image = newImage(10, 10)
+  let
+    image = newImage(256, 256)
+    subImage = image.subImage(0, 0, 128, 128)
+  doAssert subImage.width == 128 and subImage.height == 128
+
+block:
+  let image = newImage(10, 10)
   image.fill(rgba(255, 0, 0, 128))
   image.toAlphy()
   doAssert image[9, 9] == rgba(128, 0, 0, 128)
 
 block:
-  var image = newImage(10, 10)
+  let image = newImage(10, 10)
   image.fill(rgba(128, 0, 0, 128))
   image.fromAlphy()
   doAssert image[9, 9] == rgba(255, 0, 0, 128)
-
-# block:
-#   var a = newImage(100, 100)
-#   a.fill(rgba(255, 0, 0, 255))
-#   var b = newImage(100, 100)
-#   b.fill(rgba(0, 255, 0, 255))
-#   var c = a.drawOverwrite(b, translate(vec2(25, 25)))
-#   c.writeAndCheck("tests/images/drawOverwrite.png")
-
-# block:
-#   var a = newImage(100, 100)
-#   a.fill(rgba(255, 0, 0, 255))
-#   var b = newImage(100, 100)
-#   b.fill(rgba(0, 255, 0, 255))
-#   var c = a.draw(b, translate(vec2(25, 25)), bmOverwrite)
-#   c.writeAndCheck("tests/images/drawBlend.png")
-
-# block:
-#   var a = newImage(100, 100)
-#   a.fill(rgba(255, 0, 0, 255))
-#   var b = newImage(100, 100)
-#   b.fill(rgba(0, 255, 0, 255))
-#   var c = a.draw(b, translate(vec2(25.15, 25.15)), bmOverwrite)
-#   c.writeAndCheck("tests/images/drawBlendSmooth.png")
-
-# block:
-#   var a = newImage(100, 100)
-#   a.fill(rgba(255, 0, 0, 255))
-#   var b = newImage(100, 100)
-#   b.fill(rgba(0, 255, 0, 255))
-
-#   var c = a.draw(b, translate(vec2(25, 25)) * rotationMat3(PI/2))
-#   c.writeAndCheck("tests/images/drawOverwriteRot.png")
 
 block:
   let


### PR DESCRIPTION
before:
`subImage ........................... 0.126 ms      0.139 ms    ±0.015  x1000`
after:
`subImage ........................... 0.024 ms      0.027 ms    ±0.003  x1000`