### PR TITLE
applyOpacity simd for image too, 10x faster as well 

### DIFF
--- a/src/pixie/masks.nim
+++ b/src/pixie/masks.nim
@@ -116,6 +116,10 @@ proc applyOpacity*(mask: Mask, opacity: float32) =
   ## Multiplies the values of the mask by opacity.
   let opacity = round(255 * opacity).uint16
 
+  if opacity == 0:
+    mask.fill(0)
+    return
+
   var i: int
   when defined(amd64) and not defined(pixieNoSimd):
     let

--- a/tests/test_images.nim
+++ b/tests/test_images.nim
@@ -29,6 +29,13 @@ block:
   doAssert image[9, 9] == rgba(254, 0, 0, 128)
 
 block:
+  let image = newImage(100, 100)
+  image.fill(rgba(200, 200, 200, 200))
+  image.applyOpacity(0.5)
+  doAssert image[0, 0] == rgba(100, 100, 100, 100)
+  doAssert image[88, 88] == rgba(100, 100, 100, 100)
+
+block:
   let
     a = newImage(101, 101)
     b = newImage(50, 50)


### PR DESCRIPTION
2560x1440 image
before:
`applyOpacity ....................... 7.058 ms      7.172 ms    ±0.116   x695`
after:
`applyOpacity ....................... 0.759 ms      0.779 ms    ±0.038  x1000`