### PR TITLE
faster paths.nim

### DIFF
--- a/experiments/benchmark_cairo.nim
+++ b/experiments/benchmark_cairo.nim
@@ -1,4 +1,4 @@
-import cairo, math, benchy, pixie, pixie/paths, chroma
+import cairo, math, benchy, pixie, chroma
 
 var
   surface = imageSurfaceCreate(FORMAT_ARGB32, 1000, 1000)
@@ -18,7 +18,7 @@ timeIt "cairo":
   ctx.fill()
   surface.flush()
 
-discard surface.writeToPng("cairo.png")
+# discard surface.writeToPng("cairo.png")
 
 var a = newImage(1000, 1000)
 a.fill(rgba(0, 0, 0, 255))
@@ -32,4 +32,4 @@ timeIt "pixie":
   p.closePath()
   a.fillPath(p, rgba(0, 0, 255, 255))
 
-discard surface.writeToPng("pixie.png")
+# a.writeFile("pixie.png")

--- a/src/pixie/blends.nim
+++ b/src/pixie/blends.nim
@@ -160,7 +160,7 @@ proc SetSat(C: Color, s: float32): Color {.inline.} =
   if satC > 0:
     result = (C - min([C.r, C.g, C.b])) * s / satC
 
-proc blendNormal(backdrop, source: ColorRGBA): ColorRGBA =
+proc blendNormal*(backdrop, source: ColorRGBA): ColorRGBA =
   if backdrop.a == 0:
     return source
   if source.a == 255:
@@ -516,6 +516,31 @@ when defined(amd64) and not defined(pixieNoSimd):
     result = mm_or_si128(mm_or_si128(result, i), mm_or_si128(j, k))
     result = mm_and_si128(result, first32)
 
+  proc unpackAlphaValues*(v: M128i): M128i {.inline.} =
+    ## Unpack the first 32 bits into 4 rgba(0, 0, 0, value)
+    let
+      first32 = cast[M128i]([uint32.high, 0, 0, 0]) # First 32 bits
+      alphaMask = mm_set1_epi32(cast[int32](0xff000000)) # Only `a`
+
+    result = mm_shuffle_epi32(v, MM_SHUFFLE(0, 0, 0, 0))
+
+    var
+      i = mm_and_si128(result, first32)
+      j = mm_and_si128(result, mm_slli_si128(first32, 4))
+      k = mm_and_si128(result, mm_slli_si128(first32, 8))
+      l = mm_and_si128(result, mm_slli_si128(first32, 12))
+
+    # Shift the values to `a`
+    i = mm_slli_si128(i, 3)
+    j = mm_slli_si128(j, 2)
+    k = mm_slli_si128(k, 1)
+    # l = mm_slli_si128(l, 0)
+
+    result = mm_and_si128(
+      mm_or_si128(mm_or_si128(i, j), mm_or_si128(k, l)),
+      alphaMask
+    )
+
   proc blendNormalSimd*(backdrop, source: M128i): M128i =
     let
       alphaMask = mm_set1_epi32(cast[int32](0xff000000))
@@ -615,9 +640,7 @@ when defined(amd64) and not defined(pixieNoSimd):
       blendedEven = mm_add_epi16(sourceEven, backdropEven)
       blendedOdd = mm_add_epi16(sourceOdd, backdropOdd)
 
-    blendedOdd = mm_slli_epi16(blendedOdd, 8)
-
-    mm_or_si128(blendedEven, blendedOdd)
+    mm_or_si128(blendedEven, mm_slli_epi16(blendedOdd, 8))
 
   proc maskMaskSimd*(backdrop, source: M128i): M128i =
     let
@@ -638,9 +661,7 @@ when defined(amd64) and not defined(pixieNoSimd):
     backdropEven = mm_srli_epi16(mm_mulhi_epu16(backdropEven, div255), 7)
     backdropOdd = mm_srli_epi16(mm_mulhi_epu16(backdropOdd, div255), 7)
 
-    backdropOdd = mm_slli_epi16(backdropOdd, 8)
-
-    mm_or_si128(backdropEven, backdropOdd)
+    mm_or_si128(backdropEven, mm_slli_epi16(backdropOdd, 8))
 
   proc maskerSimd*(blendMode: BlendMode): MaskerSimd =
     case blendMode:

--- a/src/pixie/blends.nim
+++ b/src/pixie/blends.nim
@@ -160,7 +160,7 @@ proc SetSat(C: Color, s: float32): Color {.inline.} =
   if satC > 0:
     result = (C - min([C.r, C.g, C.b])) * s / satC
 
-proc blendNormal*(backdrop, source: ColorRGBA): ColorRGBA =
+proc blendNormal(backdrop, source: ColorRGBA): ColorRGBA =
   if backdrop.a == 0:
     return source
   if source.a == 255:
@@ -541,7 +541,7 @@ when defined(amd64) and not defined(pixieNoSimd):
       alphaMask
     )
 
-  proc blendNormalSimd*(backdrop, source: M128i): M128i =
+  proc blendNormalSimd(backdrop, source: M128i): M128i =
     let
       alphaMask = mm_set1_epi32(cast[int32](0xff000000))
       oddMask = mm_set1_epi16(cast[int16](0xff00))
@@ -570,7 +570,7 @@ when defined(amd64) and not defined(pixieNoSimd):
       mm_or_si128(backdropEven, mm_slli_epi16(backdropOdd, 8))
     )
 
-  proc blendMaskSimd*(backdrop, source: M128i): M128i =
+  proc blendMaskSimd(backdrop, source: M128i): M128i =
     let
       alphaMask = mm_set1_epi32(cast[int32](0xff000000))
       oddMask = mm_set1_epi16(cast[int16](0xff00))
@@ -591,7 +591,7 @@ when defined(amd64) and not defined(pixieNoSimd):
 
     mm_or_si128(backdropEven, mm_slli_epi16(backdropOdd, 8))
 
-  proc blendOverwriteSimd*(backdrop, source: M128i): M128i =
+  proc blendOverwriteSimd(backdrop, source: M128i): M128i =
     source
 
   proc blenderSimd*(blendMode: BlendMode): BlenderSimd =
@@ -605,7 +605,7 @@ when defined(amd64) and not defined(pixieNoSimd):
   proc hasSimdBlender*(blendMode: BlendMode): bool =
     blendMode in {bmNormal, bmMask, bmOverwrite}
 
-  proc maskNormalSimd*(backdrop, source: M128i): M128i =
+  proc maskNormalSimd(backdrop, source: M128i): M128i =
     ## Blending masks
     let
       oddMask = mm_set1_epi16(cast[int16](0xff00))
@@ -642,7 +642,7 @@ when defined(amd64) and not defined(pixieNoSimd):
 
     mm_or_si128(blendedEven, mm_slli_epi16(blendedOdd, 8))
 
-  proc maskMaskSimd*(backdrop, source: M128i): M128i =
+  proc maskMaskSimd(backdrop, source: M128i): M128i =
     let
       oddMask = mm_set1_epi16(cast[int16](0xff00))
       div255 = mm_set1_epi16(cast[int16](0x8081))

--- a/src/pixie/images.nim
+++ b/src/pixie/images.nim
@@ -686,10 +686,7 @@ proc drawUber(a, b: Image | Mask, mat = mat3(), blendMode = bmNormal) =
           # Check we are not rotated before using SIMD blends
           when type(a) is Image:
             if blendMode.hasSimdBlender():
-              let
-                blenderSimd = blendMode.blenderSimd()
-                first32 = cast[M128i]([uint32.high, 0, 0, 0]) # First 32 bits
-                alphaMask = mm_set1_epi32(cast[int32](0xff000000)) # Only `a`
+              let blenderSimd = blendMode.blenderSimd()
               for _ in countup(x, xMax - 4, 4):
                 let
                   srcPos = p + dx * x.float32 + dy * y.float32
@@ -701,24 +698,7 @@ proc drawUber(a, b: Image | Mask, mat = mat3(), blendMode = bmNormal) =
                 else: # b is a Mask
                   # Need to move 4 mask values into the alpha slots
                   var source = mm_loadu_si128(b.data[b.dataIndex(sx, sy)].addr)
-                  source = mm_slli_si128(source, 2)
-                  source = mm_shuffle_epi32(source, MM_SHUFFLE(1, 1, 0, 0))
-
-                  var
-                    i = mm_and_si128(source, first32)
-                    j = mm_and_si128(source, mm_slli_si128(first32, 4))
-                    k = mm_and_si128(source, mm_slli_si128(first32, 8))
-                    l = mm_and_si128(source, mm_slli_si128(first32, 12))
-
-                  # Shift the values to `a`
-                  i = mm_slli_si128(i, 1)
-                  k = mm_slli_si128(k, 3)
-                  l = mm_slli_si128(l, 2)
-
-                  source = mm_and_si128(
-                    mm_or_si128(mm_or_si128(i, j), mm_or_si128(k, l)),
-                    alphaMask
-                  )
+                  source = unpackAlphaValues(source)
 
                 mm_storeu_si128(
                   a.data[a.dataIndex(x, y)].addr,

--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -1050,6 +1050,10 @@ proc fillShapes(
     coverages = newSeq[uint8](mask.width)
     hits = newSeq[(float32, int16)](4)
 
+
+  when defined(amd64) and not defined(pixieNoSimd):
+    let maskerSimd = bmNormal.maskerSimd()
+
   for y in startY ..< stopY:
     # Reset buffer for this row
     zeroMem(coverages[0].addr, coverages.len)
@@ -1076,7 +1080,7 @@ proc fillShapes(
           let backdrop = mm_loadu_si128(mask.data[mask.dataIndex(x, y)].addr)
           mm_storeu_si128(
             mask.data[mask.dataIndex(x, y)].addr,
-            maskNormalSimd(backdrop, coverage)
+            maskerSimd(backdrop, coverage)
           )
         x += 16
 


### PR DESCRIPTION
tiger timing `nim c -d:release --debugger:native -f -r .\tests\benchmark_svg.nim`
before:
`svg decode ........................ 36.423 ms     37.024 ms    ±0.465   x135`
after:
`svg decode ........................ 23.111 ms     24.079 ms    ±0.677   x207`