### PR TITLE
use zippy bitstream in gif.nim

### DIFF
--- a/tests/benchmark_gif.nim
+++ b/tests/benchmark_gif.nim
@@ -1,0 +1,6 @@
+import benchy, pixie/fileformats/gif
+
+let data = readFile("tests/images/gif/audrey.gif")
+
+timeIt "pixie decode":
+  keep decodeGif(data)

--- a/tests/test_gif.nim
+++ b/tests/test_gif.nim
@@ -1,13 +1,13 @@
-import pixie/fileformats/gif, pixie/fileformats/png, pixie
+import pixie/fileformats/gif, pixie
 
 var img = decodeGIF(readFile("tests/images/gif/3x5.gif"))
-writeFile("tests/images/gif/3x5.png", img.encodePng())
+img.writeFile("tests/images/gif/3x5.png")
 
 var img2 = decodeGIF(readFile("tests/images/gif/audrey.gif"))
-writeFile("tests/images/gif/audrey.png", img2.encodePng())
+img2.writeFile("tests/images/gif/audrey.png")
 
 var img3 = decodeGIF(readFile("tests/images/gif/sunflower.gif"))
-writeFile("tests/images/gif/sunflower.png", img3.encodePng())
+img3.writeFile("tests/images/gif/sunflower.png")
 
 var img4 = readImage("tests/images/gif/sunflower.gif")
 doAssert img3.data == img4.data


### PR DESCRIPTION
before: `pixie decode ....................... 1.851 ms      1.896 ms    ±0.059  x1000`
after: `pixie decode ....................... 1.589 ms      1.690 ms    ±0.102  x1000`