### PR TITLE
Add SVG scale transform and non-zero / negative viewbox offset

### DIFF
--- a/examples/data/scale.svg
+++ b/examples/data/scale.svg
@@ -1,0 +1,16 @@
+<svg viewBox="-50 -50 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- uniform scale -->
+  <circle cx="0" cy="0" r="10" fill="red"
+          transform="scale(4)" />
+
+  <!-- vertical scale -->
+  <circle cx="0" cy="0" r="10" fill="yellow"
+          transform="scale(1,4)" />
+
+  <!-- horizontal scale -->
+  <circle cx="0" cy="0" r="10" fill="pink"
+          transform="scale(4,1)" />
+
+  <!-- No scale -->
+  <circle cx="0" cy="0" r="10" fill="black" />
+</svg>

--- a/examples/scale.nim
+++ b/examples/scale.nim
@@ -1,0 +1,12 @@
+import pixie
+
+let image = newImage(100, 100)
+image.fill(rgba(255, 255, 255, 255))
+
+let flower = readImage("examples/data/scale.svg")
+
+image.draw(
+  flower
+)
+
+image.writeFile("examples/scale.png")


### PR DESCRIPTION
I have added support for the SVG `scale` transform. I also had to add support for a negative / non-zero min-x/min-y `viewBox` in order to be able to render the demo from https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform#scale