### PR TITLE
spread >10x faster

### DIFF
--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -1137,12 +1137,10 @@ iterator walk(
       # between zero and nonzero (or the last hit)
       count += winding
       continue
-    if at <= 0:
-      count += winding
-      continue
-    if shouldFill(windingRule, count):
-      yield (prevAt, at, count)
-    prevAt = at
+    if at > 0:
+      if shouldFill(windingRule, count):
+        yield (prevAt, at, count)
+      prevAt = at
     count += winding
 
   when defined(pixieLeakCheck):

--- a/tests/benchmark_masks.nim
+++ b/tests/benchmark_masks.nim
@@ -33,5 +33,31 @@ timeIt "ceil":
 
 reset()
 
-timeIt "spread":
-  mask.spread(10)
+block spread_1:
+  var p: Path
+  p.rect(500, 500, 500, 500)
+
+  timeIt "spread_1":
+    mask.fill(0)
+    mask.fillPath(p)
+    mask.spread(10)
+
+block spread_2:
+  var p: Path
+  p.rect(500, 500, 1000, 1000)
+
+  timeIt "spread_2":
+    mask.fill(0)
+    mask.fillPath(p)
+    mask.spread(10)
+
+block spread_3:
+  timeIt "spread_3":
+    mask.fill(255)
+    mask.spread(10)
+
+block spread_4:
+  timeIt "spread_4":
+    mask.fill(0)
+    mask.setValueUnsafe(1000, 1000, 255)
+    mask.spread(10)


### PR DESCRIPTION
before:
```
name ............................... min time      avg time    std dv   runs
spread_1 ......................... 755.274 ms    755.672 ms    ±0.259     x7
spread_2 ......................... 603.431 ms    603.706 ms    ±0.253     x9
spread_3 ........................... 6.811 ms      6.889 ms    ±0.126   x723
spread_4 ......................... 813.653 ms    814.233 ms    ±0.557     x7
```

after:
```
name ............................... min time      avg time    std dv   runs
spread_1 .......................... 49.026 ms     50.559 ms    ±0.793    x99
spread_2 .......................... 40.273 ms     41.585 ms    ±0.521   x121
spread_3 ........................... 8.260 ms      8.308 ms    ±0.068   x601
spread_4 .......................... 51.267 ms     53.149 ms    ±0.899    x94
```