### PR TITLE
Check that all the examples work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,3 +16,5 @@ jobs:
     - run: nimble test -d:release -d:pixieNoSimd -y
     - run: nimble test --gc:orc -d:release -y
     - run: nim cpp -d:release -r tests/all.nim
+    - shell: bash
+      run: for nimfile in $(ls examples/*.nim); do nim check $nimfile; done


### PR DESCRIPTION
This change runs `nim check` on all the nim files in `examples/`. I tried running `nim c -r examples/realtime_sdl.nim` and got this error:

```
examples/realtime_sdl.nim(29, 23) Error: undeclared identifier: 'newPaint'
```