### PR TITLE
faster flips

### DIFF
--- a/src/pixie/images.nim
+++ b/src/pixie/images.nim
@@ -179,22 +179,20 @@ proc flipHorizontal*(image: Image) {.raises: [].} =
   let w = image.width div 2
   for y in 0 ..< image.height:
     for x in 0 ..< w:
-      let
-        rgba1 = image.getRgbaUnsafe(x, y)
-        rgba2 = image.getRgbaUnsafe(image.width - x - 1, y)
-      image.setRgbaUnsafe(image.width - x - 1, y, rgba1)
-      image.setRgbaUnsafe(x, y, rgba2)
+      swap(
+        image.data[image.dataIndex(x, y)],
+        image.data[image.dataIndex(image.width - x - 1, y)]
+      )
 
 proc flipVertical*(image: Image) {.raises: [].} =
   ## Flips the image around the X axis.
   let h = image.height div 2
   for y in 0 ..< h:
     for x in 0 ..< image.width:
-      let
-        rgba1 = image.getRgbaUnsafe(x, y)
-        rgba2 = image.getRgbaUnsafe(x, image.height - y - 1)
-      image.setRgbaUnsafe(x, image.height - y - 1, rgba1)
-      image.setRgbaUnsafe(x, y, rgba2)
+      swap(
+        image.data[image.dataIndex(x, y)],
+        image.data[image.dataIndex(x, image.height - y - 1)]
+      )
 
 proc subImage*(image: Image, x, y, w, h: int): Image {.raises: [PixieError].} =
   ## Gets a sub image from this image.

--- a/tests/benchmark_images.nim
+++ b/tests/benchmark_images.nim
@@ -49,6 +49,16 @@ timeIt "magnifyBy2":
 
 reset()
 
+timeIt "flipHorizontal":
+  image.flipHorizontal()
+
+reset()
+
+timeIt "flipVertical":
+  image.flipVertical()
+
+reset()
+
 timeIt "invert":
   image.invert()
 


### PR DESCRIPTION
before:
```
name ............................... min time      avg time    std dv   runs
flipHorizontal .................... 16.326 ms     16.846 ms    ±0.286   x297
flipVertical ...................... 16.680 ms     16.774 ms    ±0.103   x298
```

after:
```
name ............................... min time      avg time    std dv   runs
flipHorizontal ..................... 2.538 ms      2.622 ms    ±0.083  x1000
flipVertical ....................... 2.642 ms      2.707 ms    ±0.062  x1000
```
`nimble test` -> no files changed (tested in tests/test_images.nim)