### PR TITLE
fix scaling for high-res screens in demo

### DIFF
--- a/src/pixie/demo.nim
+++ b/src/pixie/demo.nim
@@ -69,12 +69,14 @@ proc start*(title = "Demo", width = 800, height = 600) =
   makeContextCurrent(window)
   loadExtensions()
 
-  var xscale, yscale: cfloat
-  window.getWindowContentScale(xscale.addr, yscale.addr)
-  dpi = xscale
-  screen = newImage(int(width.float32 * dpi), int(height.float32 * dpi))
+  screen = newImage(int(width.float32), int(height.float32))
   window.setWindowSize(screen.width.cint, screen.height.cint)
-  glViewport(0, 0, screen.width.cint, screen.height.cint)
+
+  # Correct scaling for high pixel screens
+  var frameWidthScale, frameHeightScale: cint
+  getFramebufferSize(window, frameWidthScale.addr, frameHeightScale.addr)
+
+  glViewport(0, 0, frameWidthScale, frameHeightScale)
   ctx = newContext(screen)
 
   # Allocate a texture and bind it.


### PR DESCRIPTION
I mentioned on reddit that the scaling for Mac was off when you use the pixie/demo functions (https://www.reddit.com/r/nim/comments/qngpva/how_to_show_animation_in_popup_window_using_pixie/). Turns out it was a easy fix with the viewport. It works fine on my machine now but I can't check for others. Since this is my first pr I dont want to mess anything up and would love to get some feedback if somethings not right