### PR TITLE
[get/set]RgbaUnsafe, slow before faster after

### DIFF
--- a/src/pixie/images.nim
+++ b/src/pixie/images.nim
@@ -63,30 +63,30 @@ proc getRgbaUnsafe*(image: Image, x, y: int): ColorRGBX {.inline, raises: [].} =
   ## * No bounds checking *
   ## Make sure that x, y are in bounds.
   ## Failure in the assumptions will cause unsafe memory reads.
-  result = image.data[image.width * y + x]
+  image.data[image.dataIndex(x, y)]
+
+proc setRgbaUnsafe*(
+  image: Image, x, y: int, color: ColorRGBX
+) {.inline, raises: [].} =
+  ## Sets a color from (x, y) coordinates.
+  ## * No bounds checking *
+  ## Make sure that x, y are in bounds.
+  ## Failure in the assumptions will cause unsafe memory writes.
+  image.data[image.dataIndex(x, y)] = color
 
 proc `[]`*(image: Image, x, y: int): ColorRGBX {.inline, raises: [].} =
   ## Gets a pixel at (x, y) or returns transparent black if outside of bounds.
   if image.inside(x, y):
     return image.getRgbaUnsafe(x, y)
 
-proc getColor*(image: Image, x, y: int): Color {.inline, raises: [].} =
-  ## Gets a color at (x, y) or returns transparent black if outside of bounds.
-  image[x, y].color()
-
-proc setRgbaUnsafe*(
-  image: Image, x, y: int, color: SomeColor
-) {.inline, raises: [].} =
-  ## Sets a color from (x, y) coordinates.
-  ## * No bounds checking *
-  ## Make sure that x, y are in bounds.
-  ## Failure in the assumptions will cause unsafe memory writes.
-  image.data[image.dataIndex(x, y)] = color.asRgbx()
-
 proc `[]=`*(image: Image, x, y: int, color: SomeColor) {.inline, raises: [].} =
   ## Sets a pixel at (x, y) or does nothing if outside of bounds.
   if image.inside(x, y):
     image.setRgbaUnsafe(x, y, color.asRgbx())
+
+proc getColor*(image: Image, x, y: int): Color {.inline, raises: [].} =
+  ## Gets a color at (x, y) or returns transparent black if outside of bounds.
+  image[x, y].color()
 
 proc setColor*(image: Image, x, y: int, color: Color) {.inline, raises: [].} =
   ## Sets a color at (x, y) or does nothing if outside of bounds.

--- a/src/pixie/masks.nim
+++ b/src/pixie/masks.nim
@@ -43,16 +43,7 @@ proc getValueUnsafe*(mask: Mask, x, y: int): uint8 {.inline, raises: [].} =
   ## * No bounds checking *
   ## Make sure that x, y are in bounds.
   ## Failure in the assumptions will case unsafe memory reads.
-  result = mask.data[mask.width * y + x]
-
-proc `[]`*(mask: Mask, x, y: int): uint8 {.inline, raises: [].} =
-  ## Gets a value at (x, y) or returns transparent black if outside of bounds.
-  if mask.inside(x, y):
-    return mask.getValueUnsafe(x, y)
-
-proc getValue*(mask: Mask, x, y: int): uint8 {.inline, raises: [].} =
-  ## Gets a value at (x, y) or returns transparent black if outside of bounds.
-  mask[x, y]
+  result = mask.data[mask.dataIndex(x, y)]
 
 proc setValueUnsafe*(mask: Mask, x, y: int, value: uint8) {.inline, raises: [].} =
   ## Sets a value from (x, y) coordinates.
@@ -61,10 +52,19 @@ proc setValueUnsafe*(mask: Mask, x, y: int, value: uint8) {.inline, raises: [].}
   ## Failure in the assumptions will case unsafe memory writes.
   mask.data[mask.dataIndex(x, y)] = value
 
+proc `[]`*(mask: Mask, x, y: int): uint8 {.inline, raises: [].} =
+  ## Gets a value at (x, y) or returns transparent black if outside of bounds.
+  if mask.inside(x, y):
+    return mask.getValueUnsafe(x, y)
+
 proc `[]=`*(mask: Mask, x, y: int, value: uint8) {.inline, raises: [].} =
   ## Sets a value at (x, y) or does nothing if outside of bounds.
   if mask.inside(x, y):
     mask.setValueUnsafe(x, y, value)
+
+proc getValue*(mask: Mask, x, y: int): uint8 {.inline, raises: [].} =
+  ## Gets a value at (x, y) or returns transparent black if outside of bounds.
+  mask[x, y]
 
 proc setValue*(mask: Mask, x, y: int, value: uint8) {.inline, raises: [].} =
   ## Sets a value at (x, y) or does nothing if outside of bounds.


### PR DESCRIPTION
`nim c --gc:arc -r -d:release -d:pixieNoSimd --debugger:native .\tests\benchmark_paints.nim`

before:
```
GradientLinear vertical ............ 4.331 ms      4.348 ms    ±0.039  x1000
GradientLinear horizontal .......... 4.336 ms      4.349 ms    ±0.025  x1000
GradientLinear angular ............ 70.248 ms     70.907 ms    ±0.562    x71
```

after:
```
GradientLinear vertical ............ 0.592 ms      0.598 ms    ±0.010  x1000
GradientLinear horizontal .......... 1.218 ms      1.231 ms    ±0.022  x1000
GradientLinear angular ............ 67.623 ms     68.027 ms    ±0.393    x74
```




`nim c --gc:arc -d:release -d:pixieNoSimd -r --debugger:native .\tests\benchmark_svg.nim`

before:
```
svg decode ........................ 24.405 ms     24.664 ms    ±0.223   x203
```

after:
```
svg decode ........................ 19.164 ms     19.400 ms    ±0.240   x257
```

`nim c --gc:arc -r -d:release -d:pixieNoSimd --debugger:native .\tests\benchmark_images_draw.nim`

before:
```
draw small-on-big bmNormal ......... 0.024 ms      0.024 ms    ±0.000  x1000
draw small-on-big Smooth bmNormal .. 0.097 ms      0.100 ms    ±0.001  x1000
draw big-on-bigger bmNormal ........ 2.135 ms      2.148 ms    ±0.029  x1000
draw [scale 0.5] ................... 0.884 ms      0.886 ms    ±0.006  x1000
draw [scale 2] ..................... 8.682 ms      8.703 ms    ±0.029   x574
draw Smooth [x translate] .......... 8.207 ms      8.555 ms    ±0.102   x583
draw Smooth [y translate] .......... 9.192 ms      9.541 ms    ±0.101   x523
draw Smooth [x + y translate] ...... 8.911 ms      8.989 ms    ±0.059   x555
draw Smooth [rotate 45 deg] ........ 7.171 ms      7.330 ms    ±0.089   x682
draw mask Smooth [rotate 45 deg] ... 4.508 ms      4.552 ms    ±0.035  x1000
shadow (no offset) ................. 0.401 ms      0.406 ms    ±0.005  x1000
shadow (with offset) ............... 0.425 ms      0.429 ms    ±0.005  x1000
```

after:
```
draw small-on-big bmNormal ......... 0.010 ms      0.011 ms    ±0.001  x1000
draw small-on-big Smooth bmNormal .. 0.064 ms      0.065 ms    ±0.001  x1000
draw big-on-bigger bmNormal ........ 0.736 ms      0.739 ms    ±0.005  x1000
draw [scale 0.5] ................... 0.407 ms      0.411 ms    ±0.007  x1000
draw [scale 2] ..................... 3.284 ms      3.297 ms    ±0.022  x1000
draw Smooth [x translate] .......... 4.228 ms      4.240 ms    ±0.013  x1000
draw Smooth [y translate] .......... 4.539 ms      4.567 ms    ±0.035  x1000
draw Smooth [x + y translate] ...... 5.540 ms      5.559 ms    ±0.024   x897
draw Smooth [rotate 45 deg] ........ 5.753 ms      5.775 ms    ±0.031   x863
draw mask Smooth [rotate 45 deg] ... 2.719 ms      2.728 ms    ±0.014  x1000
shadow (no offset) ................. 0.316 ms      0.322 ms    ±0.007  x1000
shadow (with offset) ............... 0.339 ms      0.342 ms    ±0.005  x1000
```