### PR TITLE
Mark parseGlyfGlyph prototype as gcsafe

### DIFF
--- a/src/pixie/fontformats/opentype.nim
+++ b/src/pixie/fontformats/opentype.nim
@@ -2126,7 +2126,7 @@ proc getGlyphId(opentype: OpenType, rune: Rune): uint16 =
 proc hasGlyph*(opentype: OpenType, rune: Rune): bool =
   rune in opentype.cmap.runeToGlyphId
 
-proc parseGlyfGlyph(opentype: OpenType, glyphId: uint16): Path {.raises: [PixieError].}
+proc parseGlyfGlyph(opentype: OpenType, glyphId: uint16): Path {.raises: [PixieError], gcsafe.}
 
 proc parseGlyphPath(
   buf: string, offset, numberOfContours: int


### PR DESCRIPTION
This causes problems for procs that call `fillText` and need to be gcsafe.