### PR TITLE
some jpeg

### DIFF
--- a/src/pixie/fileformats/jpeg.nim
+++ b/src/pixie/fileformats/jpeg.nim
@@ -91,7 +91,11 @@ template failInvalid(reason = "unable to load") =
 
 template clampByte(x: int32): uint8 =
   ## Clamp integer into byte range.
-  clamp(x, 0, 0xFF).uint8
+  # clamp(x, 0, 0xFF).uint8
+  let
+    signBit = (cast[uint32](x) shr 31)
+    value = cast[uint32](x) and (signBit - 1)
+  min(value, 255).uint8
 
 proc readUint8(state: var DecoderState): uint8 =
   ## Reads a byte from the input stream.

--- a/src/pixie/fileformats/jpeg.nim
+++ b/src/pixie/fileformats/jpeg.nim
@@ -757,7 +757,7 @@ proc checkReset(state: var DecoderState) =
       state.fillBitBuffer()
 
     if state.buffer[state.pos] == 0xFF.char:
-      if state.buffer[state.pos+1] in {0xD0.char .. 0xD7.char}:
+      if state.buffer[state.pos + 1] in {0xD0.char .. 0xD7.char}:
         state.pos += 2
       else:
         failInvalid("did not get expected reset marker")
@@ -892,15 +892,12 @@ proc buildImage(state: var DecoderState): Image =
           cb.unsafe[x, y],
           cr.unsafe[x, y],
         )
-
   elif state.components.len == 1:
     let
       cy = state.components[0].channel
     for y in 0 ..< state.imageHeight:
       for x in 0 ..< state.imageWidth:
-        result.unsafe[x, y] = grayScaleToRgbx(
-          cy.unsafe[x, y],
-        )
+        result.unsafe[x, y] = grayScaleToRgbx(cy.unsafe[x, y])
   else:
     failInvalid()
 

--- a/src/pixie/fileformats/jpeg.nim
+++ b/src/pixie/fileformats/jpeg.nim
@@ -311,7 +311,7 @@ proc reset(state: var DecoderState) =
   if state.restartInterval != 0:
     state.todo = state.restartInterval
   else:
-    state.todo = 0x7fffffff
+    state.todo = int.high
   state.eobRun = 0
 
 proc decodeSOS(state: var DecoderState) =


### PR DESCRIPTION
baseline (6fa7c7abd7f63217865146cce9430913d4abf22f):
```
jpeg 0k decode ..................... 0.008 ms      0.009 ms    ±0.001  x1000
jpeg 0k decode ..................... 0.008 ms      0.008 ms    ±0.001  x1000
jpeg 0k decode ..................... 0.008 ms      0.008 ms    ±0.001  x1000
jpeg 0k decode ..................... 0.008 ms      0.010 ms    ±0.002  x1000
jpeg 0k decode ..................... 0.008 ms      0.009 ms    ±0.001  x1000
jpeg 1k decode ..................... 0.005 ms      0.005 ms    ±0.000  x1000
jpeg 1k decode ..................... 0.007 ms      0.007 ms    ±0.001  x1000
jpeg 1k decode ..................... 0.011 ms      0.013 ms    ±0.001  x1000
jpeg 1k decode ..................... 0.014 ms      0.014 ms    ±0.000  x1000
jpeg 2k decode ..................... 0.114 ms      0.122 ms    ±0.010  x1000
jpeg 2k decode ..................... 0.113 ms      0.116 ms    ±0.002  x1000
jpeg 2k decode ..................... 0.114 ms      0.122 ms    ±0.012  x1000
jpeg 3k decode ..................... 0.121 ms      0.124 ms    ±0.002  x1000
jpeg 3k decode ..................... 0.120 ms      0.123 ms    ±0.003  x1000
jpeg 10k decode .................... 0.860 ms      0.926 ms    ±0.062  x1000
jpeg 10k decode .................... 0.878 ms      0.905 ms    ±0.031  x1000
jpeg 9k decode ..................... 0.741 ms      0.763 ms    ±0.028  x1000
jpeg 8k decode ..................... 0.690 ms      0.711 ms    ±0.030  x1000
jpeg 9k decode ..................... 0.694 ms      0.706 ms    ±0.017  x1000
jpeg 18k decode .................... 0.830 ms      0.841 ms    ±0.008  x1000
jpeg 10k decode .................... 1.065 ms      1.085 ms    ±0.023  x1000
jpeg 10k decode .................... 0.879 ms      0.899 ms    ±0.024  x1000
jpeg 10k decode .................... 1.069 ms      1.085 ms    ±0.017  x1000
jpeg 75k decode .................... 6.682 ms      6.937 ms    ±0.201   x718
jpeg 5k decode ..................... 0.709 ms      0.721 ms    ±0.019  x1000
jpeg 38k decode .................... 1.206 ms      1.216 ms    ±0.011  x1000
jpeg 284k decode .................. 15.896 ms     16.418 ms    ±0.328   x304
jpeg 5k decode ..................... 0.670 ms      0.689 ms    ±0.025  x1000
jpeg 5k decode ..................... 0.779 ms      0.797 ms    ±0.027  x1000
jpeg 5k decode ..................... 0.670 ms      0.683 ms    ±0.019  x1000
jpeg 5k decode ..................... 0.779 ms      0.792 ms    ±0.019  x1000
```

pr:
```
jpeg 0k decode ..................... 0.007 ms      0.007 ms    ±0.001  x1000       
jpeg 0k decode ..................... 0.007 ms      0.007 ms    ±0.001  x1000
jpeg 0k decode ..................... 0.007 ms      0.007 ms    ±0.001  x1000       
jpeg 0k decode ..................... 0.007 ms      0.007 ms    ±0.001  x1000
jpeg 0k decode ..................... 0.007 ms      0.007 ms    ±0.001  x1000       
jpeg 1k decode ..................... 0.004 ms      0.004 ms    ±0.001  x1000
jpeg 1k decode ..................... 0.006 ms      0.007 ms    ±0.001  x1000       
jpeg 1k decode ..................... 0.010 ms      0.010 ms    ±0.001  x1000
jpeg 1k decode ..................... 0.012 ms      0.013 ms    ±0.002  x1000
jpeg 2k decode ..................... 0.097 ms      0.101 ms    ±0.005  x1000
jpeg 2k decode ..................... 0.097 ms      0.100 ms    ±0.003  x1000
jpeg 2k decode ..................... 0.100 ms      0.102 ms    ±0.002  x1000
jpeg 3k decode ..................... 0.106 ms      0.108 ms    ±0.001  x1000
jpeg 3k decode ..................... 0.103 ms      0.107 ms    ±0.002  x1000
jpeg 10k decode .................... 0.739 ms      0.783 ms    ±0.050  x1000
jpeg 10k decode .................... 0.756 ms      0.773 ms    ±0.022  x1000
jpeg 9k decode ..................... 0.642 ms      0.660 ms    ±0.025  x1000
jpeg 8k decode ..................... 0.602 ms      0.613 ms    ±0.011  x1000
jpeg 9k decode ..................... 0.602 ms      0.615 ms    ±0.019  x1000
jpeg 18k decode .................... 0.744 ms      0.757 ms    ±0.013  x1000
jpeg 10k decode .................... 0.941 ms      0.964 ms    ±0.017  x1000
jpeg 10k decode .................... 0.756 ms      0.770 ms    ±0.013  x1000
jpeg 10k decode .................... 0.952 ms      0.965 ms    ±0.016  x1000
jpeg 75k decode .................... 6.013 ms      6.231 ms    ±0.152   x801
jpeg 5k decode ..................... 0.616 ms      0.629 ms    ±0.015  x1000
jpeg 38k decode .................... 1.108 ms      1.124 ms    ±0.019  x1000
jpeg 284k decode .................. 14.996 ms     15.394 ms    ±0.275   x324
jpeg 5k decode ..................... 0.589 ms      0.601 ms    ±0.015  x1000
jpeg 5k decode ..................... 0.702 ms      0.715 ms    ±0.019  x1000
jpeg 5k decode ..................... 0.589 ms      0.603 ms    ±0.019  x1000
jpeg 5k decode ..................... 0.702 ms      0.712 ms    ±0.011  x1000
```