### PR TITLE
quantize to prevent leaks with float32

### DIFF
--- a/tests/benchmark_svg.nim
+++ b/tests/benchmark_svg.nim
@@ -1,6 +1,8 @@
 import benchy, pixie/fileformats/svg
 
-let data = readFile("tests/fileformats/svg/Ghostscript_Tiger.svg")
+let
+  data = readFile("tests/fileformats/svg/Ghostscript_Tiger.svg")
+  parsed = parseSvg(data)
 
-timeIt "svg parse + render":
-  discard newImage(parseSvg(data))
+timeIt "svg render":
+  discard newImage(parsed)


### PR DESCRIPTION
now that we have split parsing an svg from rendering it, i'd like to focus the benchmark just on the rendering for the time being. the parsing is it's own thing to benchmark but the rendering is the vast majority of time.

before:
```
svg render ........................ 12.716 ms     12.755 ms    ±0.024   x392
```

after:
```
svg render ........................ 12.539 ms     12.570 ms    ±0.020   x398
```

these timings are using https://github.com/treeform/vmath/pull/54
both have no leaks with fuzz_leaks.nim or fuzz_leaks2.nim
no change in output quality (we can't do more than 256 steps of aa anyway)

this does slightly change svg output so many of the test rendered files change. im not committing them here since i have other changes that will affect all files and we've talked about a different way of handling test files as well