### PR TITLE
fillCoverage refactor

### DIFF
--- a/src/pixie/blends.nim
+++ b/src/pixie/blends.nim
@@ -238,7 +238,7 @@ proc blendScreen*(backdrop, source: ColorRGBX): ColorRGBX {.inline.} =
 #   result = alphaFix(backdrop, source, result)
 #   result = result.toPremultipliedAlpha()
 
-proc blendColorDodge(backdrop, source: ColorRGBX): ColorRGBX =
+proc blendColorDodge*(backdrop, source: ColorRGBX): ColorRGBX =
   let
     backdrop = backdrop.rgba()
     source = source.rgba()
@@ -341,7 +341,7 @@ proc blendHardLight*(backdrop, source: ColorRGBX): ColorRGBX =
   result.b = hardLight(backdrop.b, backdrop.a, source.b, source.a)
   result.a = blendAlpha(backdrop.a, source.a)
 
-proc blendDifference(backdrop, source: ColorRGBX): ColorRGBX =
+proc blendDifference*(backdrop, source: ColorRGBX): ColorRGBX =
   proc blend(
     backdropColor, backdropAlpha, sourceColor, sourceAlpha: uint8
   ): uint8 {.inline.} =
@@ -357,7 +357,7 @@ proc blendDifference(backdrop, source: ColorRGBX): ColorRGBX =
   result.b = blend(backdrop.b, backdrop.a, source.b, source.a)
   result.a = blendAlpha(backdrop.a, source.a)
 
-proc blendExclusion(backdrop, source: ColorRGBX): ColorRGBX =
+proc blendExclusion*(backdrop, source: ColorRGBX): ColorRGBX =
   proc blend(backdrop, source: uint32): uint8 {.inline.} =
     let v = (backdrop + source).int32 - ((2 * backdrop * source) div 255).int32
     max(0, v).uint8
@@ -366,28 +366,28 @@ proc blendExclusion(backdrop, source: ColorRGBX): ColorRGBX =
   result.b = blend(backdrop.b.uint32, source.b.uint32)
   result.a = blendAlpha(backdrop.a, source.a)
 
-proc blendColor(backdrop, source: ColorRGBX): ColorRGBX =
+proc blendColor*(backdrop, source: ColorRGBX): ColorRGBX =
   let
     backdrop = backdrop.rgba().color
     source = source.rgba().color
     blended = SetLum(source, Lum(backdrop))
   result = alphaFix(backdrop, source, blended).rgba.rgbx()
 
-proc blendLuminosity(backdrop, source: ColorRGBX): ColorRGBX =
+proc blendLuminosity*(backdrop, source: ColorRGBX): ColorRGBX =
   let
     backdrop = backdrop.rgba().color
     source = source.rgba().color
     blended = SetLum(backdrop, Lum(source))
   result = alphaFix(backdrop, source, blended).rgba.rgbx()
 
-proc blendHue(backdrop, source: ColorRGBX): ColorRGBX =
+proc blendHue*(backdrop, source: ColorRGBX): ColorRGBX =
   let
     backdrop = backdrop.rgba().color
     source = source.rgba().color
     blended = SetLum(SetSat(source, Sat(backdrop)), Lum(backdrop))
   result = alphaFix(backdrop, source, blended).rgba.rgbx()
 
-proc blendSaturation(backdrop, source: ColorRGBX): ColorRGBX =
+proc blendSaturation*(backdrop, source: ColorRGBX): ColorRGBX =
   let
     backdrop = backdrop.rgba().color
     source = source.rgba().color

--- a/src/pixie/fileformats/svg.nim
+++ b/src/pixie/fileformats/svg.nim
@@ -550,6 +550,7 @@ proc newImage*(svg: Svg): Image {.raises: [PixieError].} =
   result = newImage(svg.width, svg.height)
 
   try:
+    var blendMode = OverwriteBlend # Start as overwrite
     for (path, props) in svg.elements:
       if props.display and props.opacity > 0:
         if props.fill != "none":
@@ -573,8 +574,11 @@ proc newImage*(svg: Svg): Image {.raises: [PixieError].} =
             paint = parseHtmlColor(props.fill).rgbx
 
           paint.opacity = props.fillOpacity * props.opacity
+          paint.blendMode = blendMode
 
           result.fillPath(path, paint, props.transform, props.fillRule)
+
+        blendMode = NormalBlend # Switch to normal when compositing multiple paths
 
         if props.stroke != rgbx(0, 0, 0, 0) and props.strokeWidth > 0:
           let paint = newPaint(props.stroke)

--- a/src/pixie/fileformats/tiff.nim
+++ b/src/pixie/fileformats/tiff.nim
@@ -7,14 +7,14 @@ const
   ]
   knownTags = [
     0x0100.uint16, # ImageWidth
-    0x0101, # ImageLength
-    0x0102, # BitsPerSample
-    0x0103, # Compression
-    0x0106, # PhotometricInterpretation
-    0x0111, # StripOffsets
-    0x0116, # RowsPerStrip
-    0x0117, # StripByteCounts
-    0x0140, # ColorMap
+    0x0101,        # ImageLength
+    0x0102,        # BitsPerSample
+    0x0103,        # Compression
+    0x0106,        # PhotometricInterpretation
+    0x0111,        # StripOffsets
+    0x0116,        # RowsPerStrip
+    0x0117,        # StripByteCounts
+    0x0140,        # ColorMap
   ]
 
 type

--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -1429,6 +1429,8 @@ proc fillCoverage(
       let coverage = coverages[x - startX]
       if coverage == 255 and rgbx.a == 255:
         image.unsafe[x, y] = rgbx
+      elif coverage == 0:
+        discard
       else:
         let backdrop = image.unsafe[x, y]
         image.unsafe[x, y] = blendNormal(backdrop, source(rgbx, coverage))

--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -1357,7 +1357,9 @@ proc fillCoverage(
         sourceOdd = mm_srli_epi16(mm_mulhi_epu16(sourceOdd, div255), 7)
         result = mm_or_si128(sourceEven, mm_slli_epi16(sourceOdd, 8))
 
-      iterator simd(coverages: seq[uint8], x: var int, startX: int): (M128i, bool, bool) =
+      iterator simd(
+        coverages: seq[uint8], x: var int, startX: int
+      ): (M128i, bool, bool) =
         for _ in 0 ..< coverages.len div 16:
           let
             coverageVec = mm_loadu_si128(coverages[x - startX].unsafeAddr)

--- a/tests/benchmark_blends.nim
+++ b/tests/benchmark_blends.nim
@@ -1,6 +1,4 @@
-import benchy, chroma, pixie/images, vmath
-
-include pixie/blends
+import benchy, chroma, pixie/blends, pixie/images, vmath
 
 let
   backdrop = newImage(256, 256)

--- a/tests/benchmark_paths.nim
+++ b/tests/benchmark_paths.nim
@@ -47,6 +47,16 @@ block:
     image.fill(rgbx(255, 255, 255, 255))
     image.fillPath(rect, paint)
 
+  timeIt "rect Image SubtractMaskBlend":
+    paint.blendMode = SubtractMaskBlend
+    image.fill(rgbx(255, 255, 255, 255))
+    image.fillPath(rect, paint)
+
+  timeIt "rect Image ExcludeMaskBlend":
+    paint.blendMode = ExcludeMaskBlend
+    image.fill(rgbx(255, 255, 255, 255))
+    image.fillPath(rect, paint)
+
   timeIt "roundedRect Image OverwriteBlend":
     paint.blendMode = OverwriteBlend
     image.fillPath(roundedRect, paint)
@@ -57,6 +67,16 @@ block:
 
   timeIt "roundedRect Image MaskBlend":
     paint.blendMode = MaskBlend
+    image.fill(rgbx(255, 255, 255, 255))
+    image.fillPath(roundedRect, paint)
+
+  timeIt "roundedRect Image SubtractMaskBlend":
+    paint.blendMode = SubtractMaskBlend
+    image.fill(rgbx(255, 255, 255, 255))
+    image.fillPath(roundedRect, paint)
+
+  timeIt "roundedRect Image ExcludeMaskBlend":
+    paint.blendMode = ExcludeMaskBlend
     image.fill(rgbx(255, 255, 255, 255))
     image.fillPath(roundedRect, paint)
 


### PR DESCRIPTION
before:
```
svg render ........................ 11.926 ms     12.011 ms    ±0.121   x415 [simd]
svg render ........................ 17.460 ms     17.571 ms    ±0.181   x284 [no simd]
```

after:
```
svg render ........................ 11.761 ms     11.832 ms    ±0.103   x422 [simd]
svg render ........................ 15.190 ms     15.301 ms    ±0.142   x326 [no simd]
```