### PR TITLE
faster simple path filling

### DIFF
--- a/experiments/benchmark_cairo.nim
+++ b/experiments/benchmark_cairo.nim
@@ -13,21 +13,33 @@ type
 
 var benchmarks: seq[Benchmark]
 
+let
+  opaque = newPaint(SolidPaint)
+  notOpaque = newPaint(SolidPaint)
+opaque.color = color(0, 0, 0, 1)
+notOpaque.color = color(0, 0, 0, 0.5)
+
 block: # Basic rect
   let path = newPath()
-  path.rect(rect(0, 0, 900, 900))
+  path.rect(rect(50, 50, 800, 800))
 
-  let
-    shapes = path.commandsToShapes(true, 1)
-    paint = newPaint(SolidPaint)
-  paint.color = color(0, 0, 0, 1)
+  let shapes = path.commandsToShapes(true, 1)
 
   benchmarks.add(Benchmark(
-    name: "rect",
+    name: "rect opaque",
     fills: @[Fill(
     shapes: shapes,
     transform: mat3(),
-    paint: paint,
+    paint: opaque,
+    windingRule: NonZero
+  )]))
+
+  benchmarks.add(Benchmark(
+    name: "rect not opaque",
+    fills: @[Fill(
+    shapes: shapes,
+    transform: mat3(),
+    paint: notOpaque,
     windingRule: NonZero
   )]))
 
@@ -35,17 +47,23 @@ block: # Rounded rect
   let path = newPath()
   path.roundedRect(rect(0, 0, 900, 900), 20, 20, 20, 20)
 
-  let
-    shapes = path.commandsToShapes(true, 1)
-    paint = newPaint(SolidPaint)
-  paint.color = color(0, 0, 0, 1)
+  let shapes = path.commandsToShapes(true, 1)
 
   benchmarks.add(Benchmark(
-    name: "roundedRect",
+    name: "roundedRect opaque",
     fills: @[Fill(
     shapes: shapes,
     transform: mat3(),
-    paint: paint,
+    paint: opaque,
+    windingRule: NonZero
+    )]))
+
+  benchmarks.add(Benchmark(
+    name: "roundedRect not opaque",
+    fills: @[Fill(
+    shapes: shapes,
+    transform: mat3(),
+    paint: notOpaque,
     windingRule: NonZero
     )]))
 
@@ -58,17 +76,23 @@ block: # Heart
       Q 100,600 100,300 z
   """)
 
-  let
-    shapes = path.commandsToShapes(true, 1)
-    paint = newPaint(SolidPaint)
-  paint.color = color(0, 0, 0, 1)
+  let shapes = path.commandsToShapes(true, 1)
 
   benchmarks.add(Benchmark(
-    name: "Heart",
+    name: "heart opaque",
     fills: @[Fill(
     shapes: shapes,
     transform: mat3(),
-    paint: paint,
+    paint: opaque,
+    windingRule: NonZero
+  )]))
+
+  benchmarks.add(Benchmark(
+    name: "heart not opaque",
+    fills: @[Fill(
+    shapes: shapes,
+    transform: mat3(),
+    paint: notOpaque,
     windingRule: NonZero
   )]))
 
@@ -111,7 +135,10 @@ block: # Tiger
           windingRule: NonZero
         ))
 
-  # benchmarks.add(fills)
+  benchmarks.add(Benchmark(
+    name: "tiger",
+    fills: fills
+  ))
 
 block:
   for benchmark in benchmarks:


### PR DESCRIPTION
before:
```
[pixie] rect opaque ................ 0.060 ms      0.062 ms    ±0.002  x1000
[pixie] rect not opaque ............ 0.145 ms      0.147 ms    ±0.002  x1000
[pixie] roundedRect opaque ......... 0.102 ms      0.104 ms    ±0.002  x1000
[pixie] roundedRect not opaque ..... 0.255 ms      0.258 ms    ±0.005  x1000
[pixie] tiger ..................... 10.053 ms     10.265 ms    ±0.211   x486
```

after:
```
[pixie] rect opaque ................ 0.046 ms      0.055 ms    ±0.010  x1000
[pixie] rect not opaque ............ 0.127 ms      0.129 ms    ±0.005  x1000
[pixie] roundedRect opaque ......... 0.091 ms      0.093 ms    ±0.002  x1000
[pixie] roundedRect not opaque ..... 0.239 ms      0.242 ms    ±0.005  x1000
[pixie] tiger ..................... 10.086 ms     10.141 ms    ±0.061   x491
```

----

cairo:
```
[cairo] rect opaque ................ 0.035 ms      0.038 ms    ±0.005  x1000
[cairo] rect not opaque ............ 0.142 ms      0.145 ms    ±0.006  x1000 < pixie is now winning here
[cairo] roundedRect opaque ......... 0.053 ms      0.055 ms    ±0.003  x1000
[cairo] roundedRect not opaque ..... 0.192 ms      0.194 ms    ±0.003  x1000
[cairo] tiger ..................... 12.885 ms     13.009 ms    ±0.137   x383 < pixie has won here for a while now
```
