### PR TITLE
2 pixel-aligned vertical lines shortcut

### DIFF
--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -1180,13 +1180,11 @@ proc partitionSegments(
 
   for partition in result.mitems:
     partition.requiresAntiAliasing = requiresAntiAliasing(partition.entries)
-
-    let
-      top = partition.top.float32
-      bottom = partition.bottom.float32
     if partition.entries.len == 2:
       # Clip the entries to the parition bounds
       let
+        top = partition.top.float32
+        bottom = partition.bottom.float32
         topLine = line(vec2(0, top), vec2(1000, top))
         bottomLine = line(vec2(0, bottom), vec2(1000, bottom))
       for entry in partition.entries.mitems:


### PR DESCRIPTION
before:
```
[pixie] rect opaque ................ 0.042 ms      0.046 ms    ±0.004  x1000
[pixie] rect not opaque ............ 0.132 ms      0.134 ms    ±0.005  x1000
[pixie] roundedRect opaque ......... 0.082 ms      0.088 ms    ±0.006  x1000
[pixie] roundedRect not opaque ..... 0.242 ms      0.246 ms    ±0.011  x1000
```

after:
```
[pixie] rect opaque ................ 0.035 ms      0.037 ms    ±0.004  x1000 < tied now
[pixie] rect not opaque ............ 0.123 ms      0.127 ms    ±0.009  x1000 < even faster
[pixie] roundedRect opaque ......... 0.066 ms      0.069 ms    ±0.002  x1000 < getting better
[pixie] roundedRect not opaque ..... 0.235 ms      0.239 ms    ±0.011  x1000 < getting better
```

cairo:
```
[cairo] rect opaque ................ 0.035 ms      0.037 ms    ±0.004  x1000
[cairo] rect not opaque ............ 0.142 ms      0.145 ms    ±0.007  x1000
[cairo] roundedRect opaque ......... 0.053 ms      0.060 ms    ±0.009  x1000
[cairo] roundedRect not opaque ..... 0.192 ms      0.195 ms    ±0.006  x1000
```