### PR TITLE
faster draw smooth using line gather then blend

### DIFF
--- a/pixie.nimble
+++ b/pixie.nimble
@@ -1,4 +1,4 @@
-version     = "4.4.0"
+version     = "5.0.0"
 author      = "Andre von Houck and Ryan Oldenburg"
 description = "Full-featured 2d graphics library for Nim."
 license     = "MIT"


### PR DESCRIPTION
After this PR, essentially all time is spent gathering pixel samples into the line. The blending is 0.1ms out of 4.8ms of a smooth draw for example of the scale.

This PR does not attempt to make the pixel bilinear sampling faster, it just separates the gathering of the line samples and the blending of the line.