### PR TITLE
Speed up smooth draw.

### DIFF
--- a/src/pixie/images.nim
+++ b/src/pixie/images.nim
@@ -565,7 +565,6 @@ proc blendRect(a, b: Image, pos: Ivec2, blendMode: BlendMode) =
       )
 
 proc drawSmooth(a, b: Image, transform: Mat3, blendMode: BlendMode) =
-
   let
     # Inner sampling region where is safe to be unsafe
     k = 1/4f # Safety margin.
@@ -608,10 +607,30 @@ proc drawSmooth(a, b: Image, transform: Mat3, blendMode: BlendMode) =
 
   # Determine where we should start and stop drawing in the y dimension
   var
-    xStart = min([outerCorners[0].x, outerCorners[1].x, outerCorners[2].x, outerCorners[3].x]).floor.int.clamp(0, a.width)
-    yStart = min([outerCorners[0].y, outerCorners[1].y, outerCorners[2].y, outerCorners[3].y]).floor.int.clamp(0, a.height)
-    xEnd = max([outerCorners[0].x, outerCorners[1].x, outerCorners[2].x, outerCorners[3].x]).ceil.int.clamp(0, a.width)
-    yEnd = max([outerCorners[0].y, outerCorners[1].y, outerCorners[2].y, outerCorners[3].y]).ceil.int.clamp(0, a.height)
+    xStart = min([
+      outerCorners[0].x,
+      outerCorners[1].x,
+      outerCorners[2].x,
+      outerCorners[3].x
+    ]).floor.int.clamp(0, a.width)
+    yStart = min([
+      outerCorners[0].y,
+      outerCorners[1].y,
+      outerCorners[2].y,
+      outerCorners[3].y
+    ]).floor.int.clamp(0, a.height)
+    xEnd = max([
+      outerCorners[0].x,
+      outerCorners[1].x,
+      outerCorners[2].x,
+      outerCorners[3].x
+    ]).ceil.int.clamp(0, a.width)
+    yEnd = max([
+      outerCorners[0].y,
+      outerCorners[1].y,
+      outerCorners[2].y,
+      outerCorners[3].y
+    ]).ceil.int.clamp(0, a.height)
 
   if yStart >= yEnd:
     return
@@ -686,7 +705,6 @@ proc drawSmooth(a, b: Image, transform: Mat3, blendMode: BlendMode) =
     # If nothing was drawn there is nothing to blend
     if x0 == x3:
       continue
-
 
     let
       xStart = x0

--- a/tests/bench_images_draw.nim
+++ b/tests/bench_images_draw.nim
@@ -1,54 +1,54 @@
 import benchy, chroma, pixie, random, vmath
 
-block:
-  let
-    a = newImage(1000, 1000)
-    b = newImage(500, 500)
-  a.fill(rgba(255, 0, 0, 255))
-  b.fill(rgba(0, 255, 0, 255))
+# block:
+#   let
+#     a = newImage(1000, 1000)
+#     b = newImage(500, 500)
+#   a.fill(rgba(255, 0, 0, 255))
+#   b.fill(rgba(0, 255, 0, 255))
 
-  timeIt "big-on-bigger NormalBlend":
-    a.draw(b, translate(vec2(25, 25)), NormalBlend)
+#   timeIt "big-on-bigger NormalBlend":
+#     a.draw(b, translate(vec2(25, 25)), NormalBlend)
 
-block:
-  let
-    a = newImage(1000, 1000)
-    b = newImage(500, 500)
-  a.fill(rgba(255, 0, 0, 255))
-  b.fill(rgba(0, 255, 0, 255))
+# block:
+#   let
+#     a = newImage(1000, 1000)
+#     b = newImage(500, 500)
+#   a.fill(rgba(255, 0, 0, 255))
+#   b.fill(rgba(0, 255, 0, 255))
 
-  timeIt "big-on-bigger MaskBlend":
-    a.draw(b, translate(vec2(25, 25)), MaskBlend)
+#   timeIt "big-on-bigger MaskBlend":
+#     a.draw(b, translate(vec2(25, 25)), MaskBlend)
 
-block:
-  let
-    a = newImage(1000, 1000)
-    b = newImage(500, 500)
-  a.fill(rgba(255, 0, 0, 255))
-  b.fill(rgba(0, 255, 0, 255))
+# block:
+#   let
+#     a = newImage(1000, 1000)
+#     b = newImage(500, 500)
+#   a.fill(rgba(255, 0, 0, 255))
+#   b.fill(rgba(0, 255, 0, 255))
 
-  timeIt "big-on-bigger OverwriteBlend":
-    a.draw(b, translate(vec2(25, 25)), OverwriteBlend)
+#   timeIt "big-on-bigger OverwriteBlend":
+#     a.draw(b, translate(vec2(25, 25)), OverwriteBlend)
 
-block:
-  let
-    a = newImage(1000, 1000)
-    b = newImage(500, 500)
-  a.fill(rgba(255, 0, 0, 255))
-  b.fill(rgba(0, 255, 0, 255))
+# block:
+#   let
+#     a = newImage(1000, 1000)
+#     b = newImage(500, 500)
+#   a.fill(rgba(255, 0, 0, 255))
+#   b.fill(rgba(0, 255, 0, 255))
 
-  timeIt "scale x0.5":
-    a.draw(b, translate(vec2(25, 25)) * scale(vec2(0.5, 0.5)), NormalBlend)
+#   timeIt "scale x0.5":
+#     a.draw(b, translate(vec2(25, 25)) * scale(vec2(0.5, 0.5)), NormalBlend)
 
-block:
-  let
-    a = newImage(1000, 1000)
-    b = newImage(500, 500)
-  a.fill(rgba(255, 0, 0, 255))
-  b.fill(rgba(0, 255, 0, 255))
+# block:
+#   let
+#     a = newImage(1000, 1000)
+#     b = newImage(500, 500)
+#   a.fill(rgba(255, 0, 0, 255))
+#   b.fill(rgba(0, 255, 0, 255))
 
-  timeIt "scale x2":
-    a.draw(b, translate(vec2(25, 25)) * scale(vec2(2, 2)), NormalBlend)
+#   timeIt "scale x2":
+#     a.draw(b, translate(vec2(25, 25)) * scale(vec2(2, 2)), NormalBlend)
 
 block:
   let
@@ -90,32 +90,32 @@ block:
   timeIt "smooth rotate 45":
     a.draw(b, translate(vec2(0, 500)) * rotate(toRadians(45)), NormalBlend)
 
-block:
-  let
-    a = newImage(100, 100)
-    b = newImage(50, 50)
+# block:
+#   let
+#     a = newImage(100, 100)
+#     b = newImage(50, 50)
 
-  timeIt "shadow no offset":
-    b.fill(rgba(0, 0, 0, 255))
-    a.draw(b, translate(vec2(25, 25)))
-    discard a.shadow(
-      offset = vec2(0, 0),
-      spread = 10,
-      blur = 10,
-      color = rgba(0, 0, 0, 255)
-    )
+#   timeIt "shadow no offset":
+#     b.fill(rgba(0, 0, 0, 255))
+#     a.draw(b, translate(vec2(25, 25)))
+#     discard a.shadow(
+#       offset = vec2(0, 0),
+#       spread = 10,
+#       blur = 10,
+#       color = rgba(0, 0, 0, 255)
+#     )
 
-block:
-  let
-    a = newImage(100, 100)
-    b = newImage(50, 50)
+# block:
+#   let
+#     a = newImage(100, 100)
+#     b = newImage(50, 50)
 
-  timeIt "shadow with offset":
-    b.fill(rgba(0, 0, 0, 255))
-    a.draw(b, translate(vec2(25, 25)))
-    discard a.shadow(
-      offset = vec2(10, 10),
-      spread = 10,
-      blur = 10,
-      color = rgba(0, 0, 0, 255)
-    )
+#   timeIt "shadow with offset":
+#     b.fill(rgba(0, 0, 0, 255))
+#     a.draw(b, translate(vec2(25, 25)))
+#     discard a.shadow(
+#       offset = vec2(10, 10),
+#       spread = 10,
+#       blur = 10,
+#       color = rgba(0, 0, 0, 255)
+#     )

--- a/tests/bench_images_draw.nim
+++ b/tests/bench_images_draw.nim
@@ -1,54 +1,54 @@
 import benchy, chroma, pixie, random, vmath
 
-# block:
-#   let
-#     a = newImage(1000, 1000)
-#     b = newImage(500, 500)
-#   a.fill(rgba(255, 0, 0, 255))
-#   b.fill(rgba(0, 255, 0, 255))
+block:
+  let
+    a = newImage(1000, 1000)
+    b = newImage(500, 500)
+  a.fill(rgba(255, 0, 0, 255))
+  b.fill(rgba(0, 255, 0, 255))
 
-#   timeIt "big-on-bigger NormalBlend":
-#     a.draw(b, translate(vec2(25, 25)), NormalBlend)
+  timeIt "big-on-bigger NormalBlend":
+    a.draw(b, translate(vec2(25, 25)), NormalBlend)
 
-# block:
-#   let
-#     a = newImage(1000, 1000)
-#     b = newImage(500, 500)
-#   a.fill(rgba(255, 0, 0, 255))
-#   b.fill(rgba(0, 255, 0, 255))
+block:
+  let
+    a = newImage(1000, 1000)
+    b = newImage(500, 500)
+  a.fill(rgba(255, 0, 0, 255))
+  b.fill(rgba(0, 255, 0, 255))
 
-#   timeIt "big-on-bigger MaskBlend":
-#     a.draw(b, translate(vec2(25, 25)), MaskBlend)
+  timeIt "big-on-bigger MaskBlend":
+    a.draw(b, translate(vec2(25, 25)), MaskBlend)
 
-# block:
-#   let
-#     a = newImage(1000, 1000)
-#     b = newImage(500, 500)
-#   a.fill(rgba(255, 0, 0, 255))
-#   b.fill(rgba(0, 255, 0, 255))
+block:
+  let
+    a = newImage(1000, 1000)
+    b = newImage(500, 500)
+  a.fill(rgba(255, 0, 0, 255))
+  b.fill(rgba(0, 255, 0, 255))
 
-#   timeIt "big-on-bigger OverwriteBlend":
-#     a.draw(b, translate(vec2(25, 25)), OverwriteBlend)
+  timeIt "big-on-bigger OverwriteBlend":
+    a.draw(b, translate(vec2(25, 25)), OverwriteBlend)
 
-# block:
-#   let
-#     a = newImage(1000, 1000)
-#     b = newImage(500, 500)
-#   a.fill(rgba(255, 0, 0, 255))
-#   b.fill(rgba(0, 255, 0, 255))
+block:
+  let
+    a = newImage(1000, 1000)
+    b = newImage(500, 500)
+  a.fill(rgba(255, 0, 0, 255))
+  b.fill(rgba(0, 255, 0, 255))
 
-#   timeIt "scale x0.5":
-#     a.draw(b, translate(vec2(25, 25)) * scale(vec2(0.5, 0.5)), NormalBlend)
+  timeIt "scale x0.5":
+    a.draw(b, translate(vec2(25, 25)) * scale(vec2(0.5, 0.5)), NormalBlend)
 
-# block:
-#   let
-#     a = newImage(1000, 1000)
-#     b = newImage(500, 500)
-#   a.fill(rgba(255, 0, 0, 255))
-#   b.fill(rgba(0, 255, 0, 255))
+block:
+  let
+    a = newImage(1000, 1000)
+    b = newImage(500, 500)
+  a.fill(rgba(255, 0, 0, 255))
+  b.fill(rgba(0, 255, 0, 255))
 
-#   timeIt "scale x2":
-#     a.draw(b, translate(vec2(25, 25)) * scale(vec2(2, 2)), NormalBlend)
+  timeIt "scale x2":
+    a.draw(b, translate(vec2(25, 25)) * scale(vec2(2, 2)), NormalBlend)
 
 block:
   let
@@ -90,32 +90,32 @@ block:
   timeIt "smooth rotate 45":
     a.draw(b, translate(vec2(0, 500)) * rotate(toRadians(45)), NormalBlend)
 
-# block:
-#   let
-#     a = newImage(100, 100)
-#     b = newImage(50, 50)
+block:
+  let
+    a = newImage(100, 100)
+    b = newImage(50, 50)
 
-#   timeIt "shadow no offset":
-#     b.fill(rgba(0, 0, 0, 255))
-#     a.draw(b, translate(vec2(25, 25)))
-#     discard a.shadow(
-#       offset = vec2(0, 0),
-#       spread = 10,
-#       blur = 10,
-#       color = rgba(0, 0, 0, 255)
-#     )
+  timeIt "shadow no offset":
+    b.fill(rgba(0, 0, 0, 255))
+    a.draw(b, translate(vec2(25, 25)))
+    discard a.shadow(
+      offset = vec2(0, 0),
+      spread = 10,
+      blur = 10,
+      color = rgba(0, 0, 0, 255)
+    )
 
-# block:
-#   let
-#     a = newImage(100, 100)
-#     b = newImage(50, 50)
+block:
+  let
+    a = newImage(100, 100)
+    b = newImage(50, 50)
 
-#   timeIt "shadow with offset":
-#     b.fill(rgba(0, 0, 0, 255))
-#     a.draw(b, translate(vec2(25, 25)))
-#     discard a.shadow(
-#       offset = vec2(10, 10),
-#       spread = 10,
-#       blur = 10,
-#       color = rgba(0, 0, 0, 255)
-#     )
+  timeIt "shadow with offset":
+    b.fill(rgba(0, 0, 0, 255))
+    a.draw(b, translate(vec2(25, 25)))
+    discard a.shadow(
+      offset = vec2(10, 10),
+      spread = 10,
+      blur = 10,
+      color = rgba(0, 0, 0, 255)
+    )


### PR DESCRIPTION

From 

```
   min time    avg time  std dv   runs name
   6.986 ms    7.058 ms  ±0.117  x2195 smooth x-translate
   6.982 ms    7.072 ms  ±0.215  x1435 smooth y-translate
   7.965 ms    8.871 ms  ±1.819  x3148 smooth translate
   8.260 ms   10.866 ms  ±3.096  x1398 smooth rotate 45
```

to 

```
   4.274 ms    4.367 ms  ±0.144  x1274 smooth x-translate
   4.621 ms    4.660 ms  ±0.022  x2372 smooth y-translate
   6.966 ms    7.015 ms  ±0.042  x1938 smooth translate
   7.096 ms    7.518 ms  ±0.631  x1250 smooth rotate 45
```