### PR TITLE
make public for re-use in typography (and other libraries)

### DIFF
--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -1056,7 +1056,7 @@ proc commandsToShapes*(
       shape.addSegment(at, start)
     result.add(shape)
 
-proc shapesToSegments*(shapes: seq[Polygon]): seq[(Segment, int16)] =
+proc shapesToSegments(shapes: seq[Polygon]): seq[(Segment, int16)] =
   ## Converts the shapes into a set of filtered segments with winding value.
 
   # Quantize the segment to prevent leaks

--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -651,7 +651,7 @@ proc polygon*(
   ## Adds a n-sided regular polygon at (x, y) with the parameter size.
   path.polygon(pos.x, pos.y, size, sides)
 
-proc commandsToShapes(
+proc commandsToShapes*(
   path: Path, closeSubpaths: bool, pixelScale: float32
 ): seq[Polygon] =
   ## Converts SVG-like commands to sequences of vectors.
@@ -1056,7 +1056,7 @@ proc commandsToShapes(
       shape.addSegment(at, start)
     result.add(shape)
 
-proc shapesToSegments(shapes: seq[Polygon]): seq[(Segment, int16)] =
+proc shapesToSegments*(shapes: seq[Polygon]): seq[(Segment, int16)] =
   ## Converts the shapes into a set of filtered segments with winding value.
 
   # Quantize the segment to prevent leaks


### PR DESCRIPTION
The `paths/commandsToShapes` proc is duplicated in typography. This is resulting in an error due to some cast'ing used to get some private fields. Here's the line in `typography/src/font.nim` that fails: 

```nim
  for command in cast[PathShim](path).commands:
```

Making Pixie's `commandsToShapes` public and switching typography over appears to work fine. I didn't see any significant differences in `typography` versions. The api for `commandsToShapes` appear stable enough that keeping them private wouldn't add much burden to Pixie's public api (IMHO). Also `commandsToShapes` seems like it could be useful for other libraries too. 

If you accept this PR, I'll create a similar one for typography as well. 

Here's the stacktrace: 

```
Traceback (most recent call last)
...
/Users/jaremycreechley/.nimble/pkgs/typography-0.7.13/typography/layout.nim(168) typeset
/Users/jaremycreechley/.nimble/pkgs/typography-0.7.13/typography/rasterizer.nim(43) getGlyphSize
/Users/jaremycreechley/.nimble/pkgs/typography-0.7.13/typography/rasterizer.nim(18) makeReady
/Users/jaremycreechley/.nimble/pkgs/typography-0.7.13/typography/font.nim(486) commandsToShapes
/Users/jaremycreechley/.nimble/pkgs/typography-0.7.13/typography/font.nim(313) commandsToShapes
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```
