### PR TITLE
do not use set of int literal in tiff

### DIFF
--- a/src/pixie/fileformats/tiff.nim
+++ b/src/pixie/fileformats/tiff.nim
@@ -172,7 +172,7 @@ proc decodeTiff*(data: string): Tiff =
     failInvalid()
 
   for i, bits in bitsPerSample:
-    if bits notin {8}:
+    if bits != 8:
       raise newException(
         PixieError,
         "TIFF bits per sample of " & $bits & " not supported yet"


### PR DESCRIPTION
The set `{8}` generates a value with a size of [8192 bytes](https://github.com/nim-lang/RFCs/issues/298). Changed to use a simple equals check instead.