### PR TITLE
Fix GIF background color index bounds

### DIFF
--- a/src/pixie/fileformats/gif.nim
+++ b/src/pixie/fileformats/gif.nim
@@ -41,7 +41,7 @@ proc decodeGif*(data: string): Gif {.raises: [PixieError].} =
     bgColorIndex = data.readUint8(11).int
     pixelAspectRatio = data.readUint8(12)
 
-  if bgColorIndex > globalColorTableSize:
+  if bgColorIndex >= globalColorTableSize:
     failInvalid()
 
   if pixelAspectRatio != 0:

--- a/tests/test_gif.nim
+++ b/tests/test_gif.nim
@@ -35,3 +35,20 @@ block:
     decodeGif(readFile("tests/fileformats/gif/newtons_cradle.gif"))
   doAssert animatedGif.frames.len == 36
   doAssert animatedGif.intervals.len == animatedGif.frames.len
+
+block:
+  proc addLe16(data: var string, value: int) =
+    data.add(char(value and 0xff))
+    data.add(char((value shr 8) and 0xff))
+
+  var payload = "GIF89a"
+  payload.addLe16(1)
+  payload.addLe16(1)
+  payload.add(char(0x80)) # Global color table present, size = 2 entries.
+  payload.add(char(0x02)) # One past the last valid color table index.
+  payload.add(char(0x00))
+  payload.add("\x00\x00\x00\xff\xff\xff")
+  payload.add(char(0x3b))
+
+  doAssertRaises PixieError:
+    discard decodeGif(payload)


### PR DESCRIPTION
Fixes #560.

Summary:
- Reject GIF background color indexes that are equal to the global color table size before indexing the table.
- Add a regression test using a crafted GIF with a two-entry global color table and `bgColorIndex == 2`.

Tests:
- `nim r --hints:off --warnings:off tests\test_gif.nim`
- `nim r --hints:off --warnings:off tests\tests.nim`
- `git diff --check HEAD~1..HEAD`