### PR TITLE
fixing_cpp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,4 @@ jobs:
           cd ..
           nimby install -g pixie/pixie.nimble
       - run: nim r tests/tests.nim
+      - run: nim cpp -r tests/tests.nim


### PR DESCRIPTION
Fixes the macOS ARM C++ backend build while keeping NEON SIMD enabled.

- Adds Pixie-local typed NEON load/store shims so Nim C++ emits uint8/uint32 pointers instead of void pointers for Apple arm_neon.h macros.
- Routes existing NEON load/store call sites through those shims.
- Adds the nim cpp test runner on this stacked branch, leaving the image-suite PR focused on decoder coverage.

Local checks:
- nim check --cpu:arm64 --os:macosx tests/tests.nim
- nim cpp -r tests/tests.nim