### PR TITLE
Select string image dimensions binding

### DIFF
--- a/bindings/bindings.nim
+++ b/bindings/bindings.nim
@@ -294,7 +294,7 @@ exportRefObject Context:
 exportProcs:
   decodeBase64
   decodeImage
-  decodeImageDimensions
+  decodeImageDimensions(string)
   readImage
   readImageDimensions
   readTypeface


### PR DESCRIPTION
## Summary
- Select the string overload for `decodeImageDimensions` in the generated bindings entrypoint.
- Keep the binding export unambiguous for downstream language generation.

## Validation
- Built Pixie bindings from Genny with `-d:gennyNim`.