### PR TITLE
Fix Pixie binding ABI value types

### DIFF
--- a/bindings/bindings.nim
+++ b/bindings/bindings.nim
@@ -10,10 +10,10 @@ proc checkError(): bool =
   result = lastError != nil
 
 type
-  Vector2* = object
+  Vector2* {.bycopy.} = object
     x*, y*: float32
 
-  Matrix3* = object
+  Matrix3* {.bycopy.} = object
     values*: array[9, float32]
 
 proc matrix3(): Matrix3 =
@@ -33,6 +33,21 @@ proc scale(x, y: float32): Matrix3 =
 
 proc inverse(m: Matrix3): Matrix3 =
   cast[Matrix3](inverse(cast[Mat3](m)))
+
+proc hasGlyph(typeface: Typeface, rune: int32): bool {.raises: [].} =
+  typeface.hasGlyph(Rune(rune))
+
+proc getGlyphPath(typeface: Typeface, rune: int32): Path {.raises: [].} =
+  try:
+    result = typeface.getGlyphPath(Rune(rune))
+  except:
+    lastError = currentExceptionAsPixieError()
+
+proc getAdvance(typeface: Typeface, rune: int32): float32 {.raises: [].} =
+  typeface.getAdvance(Rune(rune))
+
+proc getKerningAdjustment(typeface: Typeface, left, right: int32): float32 {.raises: [].} =
+  typeface.getKerningAdjustment(Rune(left), Rune(right))
 
 proc parseColor(s: string): Color {.raises: [PixieError]} =
   try:
@@ -193,10 +208,10 @@ exportRefObject Typeface:
     descent
     lineGap
     lineHeight
-    hasGlyph
-    getGlyphPath
-    getAdvance
-    getKerningAdjustment
+    hasGlyph(Typeface, int32)
+    getGlyphPath(Typeface, int32)
+    getAdvance(Typeface, int32)
+    getKerningAdjustment(Typeface, int32, int32)
     newFont
 
 exportRefObject Font:

--- a/bindings/bindings.nim
+++ b/bindings/bindings.nim
@@ -34,21 +34,6 @@ proc scale(x, y: float32): Matrix3 =
 proc inverse(m: Matrix3): Matrix3 =
   cast[Matrix3](inverse(cast[Mat3](m)))
 
-proc hasGlyph(typeface: Typeface, rune: int32): bool {.raises: [].} =
-  typeface.hasGlyph(Rune(rune))
-
-proc getGlyphPath(typeface: Typeface, rune: int32): Path {.raises: [].} =
-  try:
-    result = typeface.getGlyphPath(Rune(rune))
-  except:
-    lastError = currentExceptionAsPixieError()
-
-proc getAdvance(typeface: Typeface, rune: int32): float32 {.raises: [].} =
-  typeface.getAdvance(Rune(rune))
-
-proc getKerningAdjustment(typeface: Typeface, left, right: int32): float32 {.raises: [].} =
-  typeface.getKerningAdjustment(Rune(left), Rune(right))
-
 proc parseColor(s: string): Color {.raises: [PixieError]} =
   try:
     result = parseHtmlColor(s)
@@ -208,10 +193,10 @@ exportRefObject Typeface:
     descent
     lineGap
     lineHeight
-    hasGlyph(Typeface, int32)
-    getGlyphPath(Typeface, int32)
-    getAdvance(Typeface, int32)
-    getKerningAdjustment(Typeface, int32, int32)
+    hasGlyph
+    getGlyphPath
+    getAdvance
+    getKerningAdjustment
     newFont
 
 exportRefObject Font:


### PR DESCRIPTION
## Summary
- Mark custom vector and matrix binding structs as C by-value types
- Export Typeface rune APIs with C-safe integer parameters

## Verification
- nim c --mm:arc --app:lib -d:gennyZig --path:../genny/src --path:src -o:bindings/generated/pixie.dll bindings/bindings.nim