### PR TITLE
Support Unicode cmap platform records

### DIFF
--- a/src/pixie/fontformats/opentype.nim
+++ b/src/pixie/fontformats/opentype.nim
@@ -450,8 +450,8 @@ proc parseCmapTable(buf: string, offset: int): CmapTable =
     encodingRecord.offset = buf.readUint32(i + 4).swap()
     i += 8
 
-    if encodingRecord.platformID == 3:
-      # Windows
+    if encodingRecord.platformID in [0'u16, 3'u16]:
+      # Unicode or Windows
       var i = offset + encodingRecord.offset.int
       buf.eofCheck(i + 2)
 
@@ -563,7 +563,7 @@ proc parseCmapTable(buf: string, offset: int): CmapTable =
         # TODO implement other windows formats
         discard
     else:
-      # TODO implement other cmap platformIDs
+      # TODO implement legacy cmap platform IDs.
       discard
 
 proc parseHeadTable(buf: string, offset: int): HeadTable =

--- a/tests/test_fonts.nim
+++ b/tests/test_fonts.nim
@@ -5,6 +5,21 @@ proc wh(image: Image): Vec2 =
   vec2(image.width.float32, image.height.float32)
 
 block:
+  var data = readFile("tests/fonts/Ubuntu-Regular_1.ttf")
+  let
+    original = parseOpenType(data)
+    cmapOffset = original.tableRecords["cmap"].offset.int
+    encodingCount = data[cmapOffset + 2].ord shl 8 or data[cmapOffset + 3].ord
+
+  for index in 0 ..< encodingCount:
+    let recordOffset = cmapOffset + 4 + index * 8
+    data[recordOffset] = '\0'
+    data[recordOffset + 1] = '\0'
+
+  let unicodeOnly = parseOpenType(data)
+  doAssert unicodeOnly.hasGlyph('A'.Rune)
+
+block:
   var font = readFont("tests/fonts/NotoEmoji.otf")
   font.size = 26
   let image = newImage(800, 300)


### PR DESCRIPTION
Pixie currently parses cmap subtables only when the encoding record uses the Windows platform ID. Some valid fonts, including Academy Engraved LET and Apple Chancery on macOS, expose their useful cmap through the Unicode platform instead, causing Pixie to report no renderable glyphs.

Accept both Unicode (platform 0) and Windows (platform 3) cmap encoding records. The regression test converts the existing Ubuntu fixture to Unicode-only cmap records and verifies that its glyph map remains available.

Tested with:
- nim r tests/test_fonts.nim