### PR TITLE
Fix out-of-bounds write when a clip path lies outside the image

### DIFF
--- a/src/pixie/paths.nim
+++ b/src/pixie/paths.nim
@@ -1604,15 +1604,20 @@ proc fillShapes(
     segments = shapes.shapesToSegments()
     bounds = computeBounds(segments).snapToPixels()
     startX = max(0, bounds.x.int)
-    startY = max(0, bounds.y.int)
+    startY = clamp(bounds.y.int, 0, image.height)
     pathWidth =
       if startX < image.width:
         min(bounds.w.int, image.width - startX)
       else:
         0
-    pathHeight = min(image.height, (bounds.y + bounds.h).int)
+    pathHeight = clamp((bounds.y + bounds.h).int, 0, image.height)
 
   if pathWidth == 0:
+    if blendMode == MaskBlend:
+      # The path is entirely outside the image horizontally.
+      # A mask fill still needs to record that, otherwise the
+      # previous mask survives and the new clip has no effect.
+      image.clearUnsafe(0, 0, 0, image.height)
     return
 
   if pathWidth < 0:

--- a/tests/test_contexts.nim
+++ b/tests/test_contexts.nim
@@ -675,3 +675,38 @@ block:
     ctx.fillText("Abcdefghijklmnop (" & $baseline & ")", 0, y)
 
   ctx.image.xray("tests/contexts/textBaseline_1.png")
+
+block:
+  # Regression: a clip region outside the image must not write outside the image.
+  const
+    width = 420
+    height = 460
+
+  proc paintedUnderClip(clipRect: Rect): int =
+    ## Pixels painted by a full-canvas fill under `clipRect`.
+    let
+      image = newImage(width, height)
+      ctx = image.newContext()
+      first = newPath()
+    first.rect(0, 0, width.float32, height.float32)
+    ctx.clip(first) # mask == nil, so this one takes the OverwriteBlend path
+
+    let second = newPath()
+    second.rect(clipRect)
+    ctx.clip(second) # mask != nil, so this one takes the MaskBlend path
+
+    ctx.fillStyle = rgba(255, 0, 0, 255)
+    ctx.fillRect(rect(0, 0, width.float32, height.float32))
+
+    for px in image.data:
+      if px.a != 0:
+        inc result
+
+  # a clip region off each edge excludes everything
+  doAssert paintedUnderClip(rect(0, 500, 200, 100)) == 0    # below
+  doAssert paintedUnderClip(rect(0, -600, 200, 100)) == 0   # above
+  doAssert paintedUnderClip(rect(500, 0, 100, 200)) == 0    # right
+  doAssert paintedUnderClip(rect(-600, 0, 100, 200)) == 0   # left
+
+  # a clip region on the canvas is unaffected
+  doAssert paintedUnderClip(rect(10, 10, 30, 30)) == 900


### PR DESCRIPTION
### FYI

- discovered and implemented by AI (GPT-5.6-Sol & Opus 5)
- test fails on `master`
- performance assessment at the bottom

### Summary

`Context.clip` with a clip region that lies fully outside the canvas writes
outside the image buffer. Depending on where the write lands it raises
`IndexDefect` or segfaults inside the SIMD fill.

A clip region outside the canvas is ordinary Canvas2D usage — it is what you get
when clipping to something that has scrolled off — so this is reachable from the
public API without doing anything unusual.

Reproduced against 6.1.0 and against current `master`.

### Reproduction

```nim
import pixie

let
  image = newImage(420, 460)
  ctx = image.newContext()

let a = newPath()
a.rect(0, 0, 420, 460)
ctx.clip(a)                  # first clip: mask == nil -> OverwriteBlend

let b = newPath()
b.rect(0, 500, 200, 100)     # entirely below the image
ctx.clip(b)                  # second clip: mask != nil -> MaskBlend
```

### Performance

The patch changes behavior in three of the four off-canvas directions. Only one
of those three has a "before" time worth comparing, because the other two
crashed:

| clip region | before | after |
|---|---|---|
| below the canvas | out-of-bounds write | correct — no meaningful timing to compare |
| above the canvas | out-of-bounds write | correct — no meaningful timing to compare |
| **right of the canvas** | **returned immediately, silently dropping the clip** | **correct, and now costs one mask clear** |
| left of the canvas | already correct | unchanged |

So the case that gets slower is the one that previously produced a wrong result
without faulting: a `MaskBlend` fill whose path lies entirely right of the
canvas, which is the `pathWidth == 0` early return.

**How much**, per `ctx.clip()` call:

| canvas | off-canvas clip, before | off-canvas clip, after | on-canvas clip, for scale |
|---|---|---|---|
| 420×460 | 97 µs | 102 µs | 104 µs |
| 1000×1000 | 498 µs | 528 µs | 531 µs |
| 1920×1080 | 1,044 µs | 1,103 µs | 1,104 µs |

+5 to +59 µs on a call that already costs 97 to 1,044 µs — about 5%, scaling
with canvas area as any mask operation does.

After the fix, clipping to an off-canvas region costs the same as clipping to an on-canvas one.