### PR TITLE
png: decode 16-bit depth

### DIFF
--- a/src/pixie/fileformats/png.nim
+++ b/src/pixie/fileformats/png.nim
@@ -225,8 +225,11 @@ proc decodeImageData(
       of 4: 2
       of 6: 4
       else: 0 # Not possible, parseHeader validates
-    valuesPerByte = 8 div header.bitDepth.int
-    rowBytes = ceil((header.width.int * valuesPerPixel) / valuesPerByte).int
+    bytesPerValue = if header.bitDepth == 16: 2 else: 1
+    valuesPerByte = if header.bitDepth == 16: 1 else: 8 div header.bitDepth.int
+    rowBytes = ceil(
+      (header.width.int * valuesPerPixel * bytesPerValue) / valuesPerByte
+    ).int
     totalBytes = rowBytes * header.height.int
 
   # Uncompressed image data should be the total bytes of pixel data plus
@@ -234,13 +237,31 @@ proc decodeImageData(
   if uncompressed.len != totalBytes + header.height.int:
     failInvalid()
 
-  let unfiltered = unfilter(
-    uncompressed.cstring,
-    uncompressed.len,
-    header.height,
-    rowBytes,
-    max(valuesPerPixel div valuesPerByte, 1)
-  )
+  var
+    unfiltered = unfilter(
+      uncompressed.cstring,
+      uncompressed.len,
+      header.height,
+      rowBytes,
+      max(valuesPerPixel * bytesPerValue div valuesPerByte, 1)
+    )
+    bitDepth = header.bitDepth
+    transparency = transparency
+
+  if bitDepth == 16:
+    # Samples are big-endian 16 bit; keeping the high byte of each turns the
+    # rows (and any tRNS colour key) into the 8 bit layout the paths below
+    # read, which is all an 8 bit per channel image can hold anyway.
+    var reduced = newSeq[uint8](unfiltered.len div 2)
+    for i in 0 ..< reduced.len:
+      reduced[i] = unfiltered[i * 2]
+    unfiltered = move reduced
+    var reducedTransparency: string
+    for i in countup(0, transparency.high, 2):
+      reducedTransparency.add('\0')
+      reducedTransparency.add(transparency[i])
+    transparency = reducedTransparency
+    bitDepth = 8
 
   case header.colorType:
   of 0:
@@ -249,7 +270,7 @@ proc decodeImageData(
     for y in 0 ..< header.height:
       for x in 0 ..< header.width:
         var value = unfiltered[bytePos]
-        case header.bitDepth:
+        case bitDepth:
         of 1:
           value = (value shr (7 - bitPos)) and 1
           value *= 255
@@ -313,7 +334,7 @@ proc decodeImageData(
     for y in 0 ..< header.height:
       for x in 0 ..< header.width:
         var value = unfiltered[bytePos]
-        case header.bitDepth:
+        case bitDepth:
         of 1:
           value = (value shr (7 - bitPos)) and 1
           inc bitPos
@@ -444,8 +465,6 @@ proc decodePng*(data: pointer, len: int): Png {.raises: [PixieError].} =
   inc(pos, 4) # CRC
 
   # Not yet supported:
-  if header.bitDepth == 16:
-    raise newException(PixieError, "PNG 16 bit depth not supported yet")
   if header.interlaceMethod != 0:
     raise newException(PixieError, "Interlaced PNG not supported yet")
 

--- a/tests/pngsuite.nim
+++ b/tests/pngsuite.nim
@@ -7,17 +7,17 @@ const
     "basn0g02", # 2 bit (4 level) grayscale
     "basn0g04", # 4 bit (16 level) grayscale
     "basn0g08", # 8 bit (256 level) grayscale
-    # "basn0g16", # 16 bit (64k level) grayscale
+    "basn0g16", # 16 bit (64k level) grayscale
     "basn2c08", # 3x8 bits rgb color
-    # "basn2c16", # 3x16 bits rgb color
+    "basn2c16", # 3x16 bits rgb color
     "basn3p01", # 1 bit (2 color) paletted
     "basn3p02", # 2 bit (4 color) paletted
     "basn3p04", # 4 bit (16 color) paletted
     "basn3p08", # 8 bit (256 color) paletted
     "basn4a08", # 8 bit grayscale + 8 bit alpha-channel
-    # "basn4a16", # 16 bit grayscale + 16 bit alpha-channel
+    "basn4a16", # 16 bit grayscale + 16 bit alpha-channel
     "basn6a08", # 3x8 bits rgb color + 8 bit alpha-channel
-    # "basn6a16", # 3x16 bits rgb color + 16 bit alpha-channel
+    "basn6a16", # 3x16 bits rgb color + 16 bit alpha-channel
 
     # Interlaced
     # "basi0g01", # black & white
@@ -77,19 +77,19 @@ const
     # "bgai4a08", # 8 bit grayscale, alpha, no background chunk, interlaced
     # "bgai4a16", # 16 bit grayscale, alpha, no background chunk, interlaced
     "bgan6a08", # 3x8 bits rgb color, alpha, no background chunk
-    # "bgan6a16", # 3x16 bits rgb color, alpha, no background chunk
+    "bgan6a16", # 3x16 bits rgb color, alpha, no background chunk
     "bgbn4a08", # 8 bit grayscale, alpha, black background chunk
-    # "bggn4a16", # 16 bit grayscale, alpha, gray background chunk
+    "bggn4a16", # 16 bit grayscale, alpha, gray background chunk
     "bgwn6a08", # 3x8 bits rgb color, alpha, white background chunk
-    # "bgyn6a16", # 3x16 bits rgb color, alpha, yellow background chunk
+    "bgyn6a16", # 3x16 bits rgb color, alpha, yellow background chunk
 
     # "tbbn0g04", # transparent, black background chunk
-    # # "tbbn2c16", # transparent, blue background chunk
+    "tbbn2c16", # transparent, blue background chunk
     "tbbn3p08", # transparent, black background chunk
-    # # "tbgn2c16", # transparent, green background chunk
+    "tbgn2c16", # transparent, green background chunk
     "tbgn3p08", # transparent, light-gray background chunk
     "tbrn2c08", # transparent, red background chunk
-    # # "tbwn0g16", # transparent, white background chunk
+    "tbwn0g16", # transparent, white background chunk
     "tbwn3p08", # transparent, white background chunk
     "tbyn3p08", # transparent, yellow background chunk
     "tp0n0g08", # not transparent for reference (logo on gray)


### PR DESCRIPTION
16-bit PNGs (colour types 0, 2, 4 and 6) were rejected with `PNG 16 bit depth not supported yet`. Unity asset packs ship these routinely.